### PR TITLE
Allow multiple Espressif virtualenv - just use latest

### DIFF
--- a/scripts/flash_over_usb.sh
+++ b/scripts/flash_over_usb.sh
@@ -9,5 +9,6 @@ ls -al $fwfile
 echo "Add --erase-all if needed"
 sleep 5
 # This needs python and the esptool
-~/.espressif/python_env/*/bin/python -m esptool --chip esp32s3 --before default_reset --after hard_reset write_flash --flash_mode dio --flash_size 16MB --flash_freq 80m 0 $fwfile $@
+python=$(ls -tr ~/.espressif/python_env/*/bin/python|tail -1)
+$python -m esptool --chip esp32s3 --before default_reset --after hard_reset write_flash --flash_mode dio --flash_size 16MB --flash_freq 80m 0 $fwfile $@
 


### PR DESCRIPTION
Flashing script fails when multiple Espressif Python virtualenvs are installed. This quick fix just uses the latest. 