### PR TITLE
Use a dot-whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
+.*
+!.github
+!.gitignore
+
 trash/
 
 conf.json*
-
-# macOS file:
-.DS_Store
 
 # auto created when running on desktop:
 internal_filesystem/SDLPointer_2
@@ -26,7 +27,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.so
-.Python
 
 # these get created:
 c_mpos/c_mpos


### PR DESCRIPTION
I use PyCharm. So there is the .idea directory to exclude. But exclude every variant of these are boring. So i use this idea: Exclude all dot stuff and include the needed one.