### PR TITLE
Clear battery cache in ShowBattery app

### DIFF
--- a/internal_filesystem/apps/com.micropythonos.showbattery/META-INF/MANIFEST.JSON
+++ b/internal_filesystem/apps/com.micropythonos.showbattery/META-INF/MANIFEST.JSON
@@ -6,7 +6,7 @@
 "icon_url": "https://apps.micropythonos.com/apps/com.micropythonos.showbattery/icons/com.micropythonos.showbattery_0.1.1_64x64.png",
 "download_url": "https://apps.micropythonos.com/apps/com.micropythonos.showbattery/mpks/com.micropythonos.showbattery_0.1.1.mpk",
 "fullname": "com.micropythonos.showbattery",
-"version": "0.1.1",
+"version": "0.2.0",
 "category": "development",
 "activities": [
     {


### PR DESCRIPTION
Add a "Real-time values" checkbox to ShowBattery app. If checked, then the cache will be clear on
every cycle.

Bugfix: Use `mpos.time.localtime()` to get the "correct" local time with timezone offset.

Changes for Odroid-GO:

The seen "2400" values are at startup the Odroid-GO... After a while the values are somewhere
between 290 and 310... The full range is unknown, yet. But with the new calculation it looks more
realistic, then before ;)

Looks like:

<img width="2048" height="1536" alt="grafik" src="https://github.com/user-attachments/assets/cef475ff-9c52-478e-b4ec-00f3bb78ef64" />
