### PR TITLE
Updates for ODROID-GO

### DIFF
--- a/internal_filesystem/lib/mpos/main.py
+++ b/internal_filesystem/lib/mpos/main.py
@@ -104,20 +104,28 @@ def detect_board():
         if i2c0 := fail_save_i2c(sda=21, scl=22):
             if single_address_i2c_scan(i2c0, 0x68): # IMU (MPU6886)
                 return "m5stack_fire"
-  
+
+        import machine
+        unique_id_prefix = machine.unique_id()[0]
+
+        print("odroid_go ?")
+        if unique_id_prefix == 0x30:
+            return "odroid_go"
+
         print("fri3d_2024 ?")
         if i2c0 := fail_save_i2c(sda=9, scl=18):
             if single_address_i2c_scan(i2c0, 0x6B): # IMU (plus possibly the Communicator's LANA TNY at 0x38)
                 return "fri3d_2024"
 
-        import machine
-        if machine.unique_id()[0] == 0xdc: # prototype board had: dc:b4:d9:0b:7d:80
+        print("fri3d_2026 ?")
+        if unique_id_prefix == 0xDC:  # prototype board had: dc:b4:d9:0b:7d:80
             # or: if single_address_i2c_scan(i2c0, 0x6A): # IMU currently not installed on prototype board
             return "fri3d_2026"
 
-        print("odroid_go ?")
-        #if check_pins(0, 13, 27, 39): # not good because it matches other boards (like fri3d_2024 and fri3d_2026)
-        return "odroid_go"
+        raise Exception(
+            "Unknown ESP32-S3 board: couldn't detect known I2C devices or unique_id prefix"
+        )
+
 
 # EXECUTION STARTS HERE
 


### PR DESCRIPTION
Setup the "Buzzer" and play intro and outro ;) Don't know if "I2S audio" is possible.

Battery "settings": I tested to run ODROID-GO as long as it's possible. The min. raw ADC value on
ODROID-GO i have seen is 210. So update the calculation.

Fix the boot by moving ODROID-GO below `fri3d_2024` because the device will hard crash on
`fail_save_i2c(sda=9, scl=18)` like:
```
MicroPythonOS 0.8.1 running lib/mpos/main.py
matouch_esp32_s3_spi_ips_2_8_with_camera_ov3660 ?
Try to I2C initialized on sda=39 scl=38
OK
Attempt to write a single byte to I2C bus address 0x14...
No device at this address: [Errno 116] ETIMEDOUT
Attempt to write a single byte to I2C bus address 0x5d...
No device at this address: [Errno 116] ETIMEDOUT
waveshare_esp32_s3_touch_lcd_2 ?
Try to I2C initialized on sda=48 scl=47
Failed: invalid pin
m5stack_fire ?
Try to I2C initialized on sda=21 scl=22
OK
Attempt to write a single byte to I2C bus address 0x68...
No device at this address: [Errno 19] ENODEV
fri3d_2024 ?
Try to I2C initialized on sda=9 scl=18
OK

A fatal error occurred. The crash dump printed below may be used to help
determine what caused it. If you are not already running the most recent
version of MicroPython, consider upgrading. New versions often fix bugs.

To learn more about how to debug and/or report this crash visit the wiki
page at: https://github.com/micropython/micropython/wiki/ESP32-debugging

LVGL MicroPython
IDF version : v5.4
Machine     : Generic ESP32 module with SPIRAM with ESP32

Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x401b04dd  PS      : 0x00060830  A0      : 0x801b0944  A1      : 0x3ffdb390
A2      : 0x3f80d2b0  A3      : 0x00000054  A4      : 0x3f8105e8  A5      : 0x3f54b240
A6      : 0x00000001  A7      : 0xaaaaae2a  A8      : 0x00000019  A9      : 0x3ffdb370
A10     : 0xaaaaae2a  A11     : 0x00000063  A12     : 0x3ffc7ccc  A13     : 0x00000000
A14     : 0x3f4464f4  A15     : 0x00000001  SAR     : 0x00000020  EXCCAUSE: 0x0000001c
EXCVADDR: 0xaaaaae37  LBEG    : 0x401d2964  LEND    : 0x401d296d  LCOUNT  : 0x00000000

Backtrace: 0x401b04da:0x3ffdb390 0x401b0941:0x3ffdb3b0 0x40086719:0x3ffdb3d0 0x401a90da:0x3ffdb460
0x401b07ba:0x3ffdb490 0x40085de9:0x3ffdb4b0 0x401a90da:0x3ffdb540 0x401b07ba:0x3ffdb5b0
0x40085de9:0x3ffdb5d0 0x401a90da:0x3ffdb660 0x401b07ba:0x3ffdb690 0x401b083a:0x3ffdb6b0
0x401d35c1:0x3ffdb6f0 0x401d3809:0x3ffdb730 0x401b0919:0x3ffdb830 0x40085b59:0x3ffdb870
0x401a90da:0x3ffdb900 0x401b07ba:0x3ffdb970 0x401b07e2:0x3ffdb990 0x401e8d02:0x3ffdb9b0
0x401e90c9:0x3ffdba40 0x401c5b2d:0x3ffdba70
```