### PR TITLE
Add automatic WiFi reconnection when connection is lost

### DIFF
--- a/internal_filesystem/lib/mpos/net/connectivity_manager.py
+++ b/internal_filesystem/lib/mpos/net/connectivity_manager.py
@@ -29,6 +29,9 @@ class ConnectivityManager:
         self.is_connected = False      # Local network (Wi-Fi/AP) connected
         self._is_online = False         # Real internet reachability
         self.callbacks = []
+        self._reconnect_in_progress = False
+        self._offline_checks = 0       # Count consecutive offline checks
+        self._RECONNECT_INTERVAL = 15  # Attempt reconnect every 15 checks (~2 minutes at 8s interval)
 
         if not self.can_check_network:
             self.is_connected = True # If there's no way to check, then assume we're always "connected" and online
@@ -70,14 +73,38 @@ class ConnectivityManager:
         else:
             if self.wlan.isconnected():
                 self._is_online = True
+                self._offline_checks = 0
             else:
                 self._is_online = False
+                self._offline_checks += 1
+                # Periodically attempt to reconnect WiFi
+                if self._offline_checks % self._RECONNECT_INTERVAL == 0 and not self._reconnect_in_progress:
+                    self._attempt_reconnect()
 
         if self._is_online != was_online:
             status = "ONLINE" if self._is_online else "OFFLINE"
             print(f"[Connectivity] Internet => {status}")
             if notify:
                 self._notify(self._is_online)
+
+    def _attempt_reconnect(self):
+        """Attempt to reconnect WiFi in a background thread."""
+        try:
+            from .wifi_service import WifiService
+            if WifiService.wifi_busy:
+                return
+            self._reconnect_in_progress = True
+            print(f"[Connectivity] WiFi offline for ~{self._offline_checks * 8}s, attempting reconnect...")
+            import _thread
+            def reconnect_thread():
+                try:
+                    WifiService.auto_connect()
+                finally:
+                    self._reconnect_in_progress = False
+            _thread.start_new_thread(reconnect_thread, ())
+        except Exception as e:
+            print(f"[Connectivity] Reconnect failed: {e}")
+            self._reconnect_in_progress = False
 
     # === Public Android-like API ===
     def is_online(self):

--- a/internal_filesystem/lib/mpos/net/connectivity_manager.py
+++ b/internal_filesystem/lib/mpos/net/connectivity_manager.py
@@ -31,7 +31,7 @@ class ConnectivityManager:
         self.callbacks = []
         self._reconnect_in_progress = False
         self._offline_checks = 0       # Count consecutive offline checks
-        self._RECONNECT_INTERVAL = 15  # Attempt reconnect every 15 checks (~2 minutes at 8s interval)
+        self._RECONNECT_INTERVAL = 38  # Attempt reconnect every 38 checks (~5 minutes at 8s interval)
 
         if not self.can_check_network:
             self.is_connected = True # If there's no way to check, then assume we're always "connected" and online

--- a/tests/test_connectivity_manager_reconnect.py
+++ b/tests/test_connectivity_manager_reconnect.py
@@ -1,0 +1,274 @@
+"""Tests for ConnectivityManager WiFi auto-reconnection.
+
+Tests the reconnection logic added to handle the scenario where WiFi
+is unavailable at boot (e.g. router off overnight) and comes back later.
+"""
+import unittest
+import sys
+
+# Add parent directory to path for shared mocks
+sys.path.insert(0, "../tests")
+
+from mocks import make_machine_timer_module, make_usocket_module
+from network_test_helper import MockNetwork, MockTimer, MockTime, MockRequests, MockSocket
+
+# Inject machine/socket mocks
+sys.modules["machine"] = make_machine_timer_module(MockTimer)
+sys.modules["usocket"] = make_usocket_module(MockSocket)
+sys.modules['requests'] = MockRequests()
+
+# Mock _thread to run spawned threads synchronously
+_thread_calls = []
+
+class MockThreadModule:
+    @staticmethod
+    def start_new_thread(fn, args):
+        _thread_calls.append((fn, args))
+        fn()  # reconnect_thread takes no args
+
+    @staticmethod
+    def stack_size(s=0):
+        return 0
+
+sys.modules['_thread'] = MockThreadModule
+
+# Mock WifiService
+_auto_connect_calls = []
+
+class MockWifiService:
+    wifi_busy = False
+
+    @staticmethod
+    def auto_connect(network_module=None, time_module=None):
+        _auto_connect_calls.append(True)
+
+sys.modules['mpos.net.wifi_service'] = type('module', (), {'WifiService': MockWifiService})()
+
+
+def fresh_cm_import(mock_network):
+    """Helper: inject mock network and get a fresh ConnectivityManager class."""
+    sys.modules['network'] = mock_network
+    mod_key = 'mpos.net.connectivity_manager'
+    if mod_key in sys.modules:
+        del sys.modules[mod_key]
+    from mpos.net.connectivity_manager import ConnectivityManager
+    # Force HAS_NETWORK_MODULE in case the re-import didn't pick up the new mock
+    import mpos.net.connectivity_manager as cm_mod
+    cm_mod.HAS_NETWORK_MODULE = True
+    ConnectivityManager._instance = None
+    return ConnectivityManager
+
+
+class TestReconnectOfflineCounter(unittest.TestCase):
+    """Test that offline checks are counted correctly."""
+
+    def setUp(self):
+        self.mock_network = MockNetwork(connected=False)
+        MockTimer.reset_all()
+        _auto_connect_calls.clear()
+        _thread_calls.clear()
+        MockWifiService.wifi_busy = False
+        self.ConnectivityManager = fresh_cm_import(self.mock_network)
+
+    def tearDown(self):
+        self.ConnectivityManager._instance = None
+        MockTimer.reset_all()
+
+    def test_offline_counter_increments(self):
+        """Test that offline checks increment the counter."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+
+        for i in range(5):
+            timer.callback(timer)
+
+        # Init check + 5 timer checks = 6 offline checks
+        self.assertTrue(cm._offline_checks > 0)
+
+    def test_offline_counter_resets_on_connect(self):
+        """Test that counter resets when WiFi reconnects."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+
+        for i in range(5):
+            timer.callback(timer)
+        self.assertTrue(cm._offline_checks > 0)
+
+        # WiFi comes back
+        self.mock_network.set_connected(True)
+        timer.callback(timer)
+
+        self.assertEqual(cm._offline_checks, 0)
+
+    def test_no_counter_when_online(self):
+        """Test that counter stays at 0 while online."""
+        self.mock_network.set_connected(True)
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+
+        for i in range(10):
+            timer.callback(timer)
+
+        self.assertEqual(cm._offline_checks, 0)
+
+
+class TestReconnectTrigger(unittest.TestCase):
+    """Test that reconnection is triggered at the right time."""
+
+    def setUp(self):
+        self.mock_network = MockNetwork(connected=False)
+        MockTimer.reset_all()
+        _auto_connect_calls.clear()
+        _thread_calls.clear()
+        MockWifiService.wifi_busy = False
+        self.ConnectivityManager = fresh_cm_import(self.mock_network)
+
+    def tearDown(self):
+        self.ConnectivityManager._instance = None
+        MockTimer.reset_all()
+
+    def test_reconnect_triggers_at_interval(self):
+        """Test that auto_connect is called after RECONNECT_INTERVAL offline checks."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        # Init already did 1 offline check, so we need RECONNECT_INTERVAL - 1 more
+        for i in range(cm._RECONNECT_INTERVAL - 1):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 1)
+
+    def test_reconnect_triggers_periodically(self):
+        """Test that reconnection repeats at each interval."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        # Run through two full intervals (minus the init check)
+        for i in range(cm._RECONNECT_INTERVAL * 2 - 1):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 2)
+
+    def test_no_reconnect_when_online(self):
+        """Test that reconnection is not attempted while online."""
+        self.mock_network.set_connected(True)
+        self.ConnectivityManager._instance = None
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        for i in range(cm._RECONNECT_INTERVAL * 3):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 0)
+
+    def test_no_reconnect_when_wifi_busy(self):
+        """Test that reconnection is skipped when WiFi is busy."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        MockWifiService.wifi_busy = True
+
+        for i in range(cm._RECONNECT_INTERVAL * 2):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 0)
+
+    def test_no_overlapping_reconnects(self):
+        """Test that a reconnect is not started if one is already in progress."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        cm._reconnect_in_progress = True
+
+        for i in range(cm._RECONNECT_INTERVAL * 2):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 0)
+
+    def test_reconnect_clears_in_progress_flag(self):
+        """Test that _reconnect_in_progress is cleared after reconnect."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+
+        for i in range(cm._RECONNECT_INTERVAL - 1):
+            timer.callback(timer)
+
+        # Mock runs synchronously, so flag should be cleared
+        self.assertFalse(cm._reconnect_in_progress)
+
+
+class TestReconnectDesktopMode(unittest.TestCase):
+    """Test that reconnection is not attempted on desktop."""
+
+    def setUp(self):
+        if 'network' in sys.modules:
+            del sys.modules['network']
+        if 'mpos.net.connectivity_manager' in sys.modules:
+            del sys.modules['mpos.net.connectivity_manager']
+
+        from mpos.net.connectivity_manager import ConnectivityManager
+        self.ConnectivityManager = ConnectivityManager
+        ConnectivityManager._instance = None
+        MockTimer.reset_all()
+        _auto_connect_calls.clear()
+
+    def tearDown(self):
+        self.ConnectivityManager._instance = None
+        MockTimer.reset_all()
+
+    def test_no_reconnect_on_desktop(self):
+        """Test that desktop mode never triggers reconnect."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        for i in range(100):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 0)
+
+
+class TestReconnectRouterScenario(unittest.TestCase):
+    """Integration test: router off overnight, back on in the morning."""
+
+    def setUp(self):
+        self.mock_network = MockNetwork(connected=False)
+        MockTimer.reset_all()
+        _auto_connect_calls.clear()
+        _thread_calls.clear()
+        MockWifiService.wifi_busy = False
+        self.ConnectivityManager = fresh_cm_import(self.mock_network)
+
+    def tearDown(self):
+        self.ConnectivityManager._instance = None
+        MockTimer.reset_all()
+
+    def test_router_off_at_boot_then_on(self):
+        """Simulate: device boots with router off, router comes on later."""
+        cm = self.ConnectivityManager()
+        timer = MockTimer.get_timer(1)
+        _auto_connect_calls.clear()
+
+        notifications = []
+        cm.register_callback(lambda online: notifications.append(online))
+
+        self.assertFalse(cm.is_online())
+
+        # Run checks until reconnect triggers (init already did 1)
+        for i in range(cm._RECONNECT_INTERVAL - 1):
+            timer.callback(timer)
+
+        self.assertEqual(len(_auto_connect_calls), 1)
+
+        # Router comes back — WiFi reconnects
+        self.mock_network.set_connected(True)
+        timer.callback(timer)
+
+        self.assertTrue(cm.is_online())
+        self.assertTrue(True in notifications)
+        self.assertEqual(cm._offline_checks, 0)


### PR DESCRIPTION
## Problem

When WiFi is unavailable at boot (e.g. router off overnight), MicroPythonOS tries to connect 10 times over 10 seconds, then calls `wlan.active(False)` to disable the WiFi radio and conserve power. It never retries.

This means a device that boots while the router is off stays permanently offline until manually rebooted — even after the router comes back online hours later.

**Note:** This is different from a mid-session WiFi dropout. If WiFi drops while already connected, the ESP32 WLAN driver reconnects automatically and ConnectivityManager detects it. The problem is specifically when WiFi was **never connected at boot** and the radio was turned off.

## Solution

ConnectivityManager already polls connection status every 8 seconds. This PR adds reconnection logic to that existing timer:

- Count consecutive offline checks
- Every 38 checks (~5 minutes), spawn a background thread calling `WifiService.auto_connect()`
- Guard against overlapping reconnect attempts via `_reconnect_in_progress` flag
- Respect `WifiService.wifi_busy` to avoid conflicts with the WiFi settings app

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Router off at boot, on later | Stays offline forever (radio disabled) | Reconnects within ~5 minutes |
| Mid-session WiFi dropout | Auto-reconnects (ESP32 driver) | No change (already works) |
| Router off permanently | Radio disabled, no retries | Retries every ~5 min |
| Normal boot with WiFi | No change | No change |

## Automated tests

11 tests in `tests/test_connectivity_manager_reconnect.py`:
- Offline counter increments while disconnected, resets on reconnect
- Reconnect triggers at the configured interval (~5 minutes)
- Reconnect repeats periodically while offline
- No reconnect when online, when `wifi_busy`, or when already in progress
- `_reconnect_in_progress` flag cleared after completion
- Desktop mode (no network module) never triggers reconnect
- Integration: router off at boot → reconnect triggers → router comes on → device goes online

All 25 existing `test_connectivity_manager.py` tests still pass.

## Test plan
- [x] Automated: `./tests/unittest.sh tests/test_connectivity_manager_reconnect.py` — 11 tests pass
- [x] Automated: `./tests/unittest.sh tests/test_connectivity_manager.py` — 25 existing tests pass
- [ ] Manual: Boot with WiFi off → wait → turn WiFi on → device reconnects within ~5 min
- [ ] Manual: WiFi settings app open → reconnect should not interfere (`wifi_busy` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)