### PR TITLE
bugfix "unphone" target in build_mpos.sh

### DIFF
--- a/scripts/build_mpos.sh
+++ b/scripts/build_mpos.sh
@@ -129,18 +129,17 @@ if [ "$target" == "esp32" -o "$target" == "esp32s3" -o "$target" == "unphone" -o
 		flash_size="4"
 		otasupport="" # too small for 2 OTA partitions + internal storage
 	else # esp32s3 or unphone
-		if [ "$target" == "unphone" ]; then
-			partition_size="3900000"
-			flash_size="8"
-			otasupport="" # too small for 2 OTA partitions + internal storage
-		fi
-		BOARD=ESP32_GENERIC_S3
-		BOARD_VARIANT=SPIRAM_OCT
-		# These options disable hardware AES, SHA and MPI because they give warnings in QEMU: [AES] Error reading from GDMA buffer
-		# There's a 25% https download speed penalty for this, but that's usually not the bottleneck.
-		extra_configs="CONFIG_MBEDTLS_HARDWARE_AES=n CONFIG_MBEDTLS_HARDWARE_SHA=n CONFIG_MBEDTLS_HARDWARE_MPI=n"
-		# --py-freertos: add MicroPython FreeRTOS module to expose internals
-		extra_configs="$extra_configs --py-freertos"
+        if [ "$target" == "unphone" ]; then
+            flash_size="8"
+            otasupport="" # too small for 2 OTA partitions + internal storage
+        fi
+        BOARD=ESP32_GENERIC_S3
+        BOARD_VARIANT=SPIRAM_OCT
+        # These options disable hardware AES, SHA and MPI because they give warnings in QEMU: [AES] Error reading from GDMA buffer
+        # There's a 25% https download speed penalty for this, but that's usually not the bottleneck.
+        extra_configs="CONFIG_MBEDTLS_HARDWARE_AES=n CONFIG_MBEDTLS_HARDWARE_SHA=n CONFIG_MBEDTLS_HARDWARE_MPI=n"
+        # --py-freertos: add MicroPython FreeRTOS module to expose internals
+        extra_configs="$extra_configs --py-freertos"
 	fi
 
 	if [ "$BOARD_VARIANT" == "SPIRAM" -o "$BOARD_VARIANT" == "SPIRAM_OCT" ]; then


### PR DESCRIPTION
fix build error:
```
Error: app partition is too small for binary micropython.bin size 0x3cb940:
- Part 'factory' 0/0 @ 0x10000 size 0x3b9000 (overflow 0x12940)
ninja: build stopped: subcommand failed.
```

by change `partition_size="3900000"` to `partition_size="4194304"` (the default value)

I created a build and flash it: It works fine.