### PR TITLE
Fix AppearanceManager.set_light_mode / set_primary_color using non-existent prefs.set_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Frameworks:
 - Add new IRManager framework
 - Add new LoRaManager framework
 - Add mpos.ui.change_task_handler() for improving IR timing accuracy
+- AppearanceManager: fix set_light_mode() and set_primary_color() — they called a non-existent `prefs.set_string()` and raised AttributeError for every third-party caller; writes now go through `edit().put_string().commit()` and the LVGL theme is reinitialised when the colour changes
 
 OS:
 - LilyGo T-Watch S3 Plus: add support for IR Remote app

--- a/internal_filesystem/lib/mpos/ui/appearance_manager.py
+++ b/internal_filesystem/lib/mpos/ui/appearance_manager.py
@@ -143,16 +143,17 @@ class AppearanceManager:
             AppearanceManager.set_light_mode(False)  # Switch to dark mode
         """
         cls._is_light_mode = is_light
-        
-        # Save to preferences if provided
+
+        # Save to preferences if provided, then reinitialise LVGL theme.
+        # SharedPreferences doesn't have a set_string() — writes go through
+        # edit().put_string().commit().
         if prefs:
             theme_str = "light" if is_light else "dark"
-            prefs.set_string("theme_light_dark", theme_str)
-        
-        # Reinitialize LVGL theme with new mode
-        if prefs:
+            editor = prefs.edit()
+            editor.put_string("theme_light_dark", theme_str)
+            editor.commit()
             cls.init(prefs)
-        
+
         print(f"[AppearanceManager] Light mode set to: {is_light}")
     
     @classmethod
@@ -210,11 +211,16 @@ class AppearanceManager:
             AppearanceManager.set_primary_color(lv.color_hex(0xFF5722))
         """
         cls._primary_color = color
-        
-        # Save to preferences if provided
+
+        # Save to preferences if provided, then reinitialise LVGL theme so the
+        # new colour is actually applied. SharedPreferences doesn't have a
+        # set_string() — writes go through edit().put_string().commit().
         if prefs and isinstance(color, int):
-            prefs.set_string("theme_primary_color", f"0x{color:06X}")
-        
+            editor = prefs.edit()
+            editor.put_string("theme_primary_color", f"0x{color:06X}")
+            editor.commit()
+            cls.init(prefs)
+
         print(f"[AppearanceManager] Primary color set to: {color}")
     
     # ========== UI Dimensions ==========

--- a/tests/test_appearance_manager.py
+++ b/tests/test_appearance_manager.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for AppearanceManager.set_light_mode / set_primary_color.
+
+Regression tests: pre-fix these methods called prefs.set_string(...) — a method
+that does not exist on SharedPreferences — so any third-party caller supplying a
+prefs object hit AttributeError. These tests pin down the corrected
+edit/put_string/commit write path and the expected on-disk values.
+
+Usage:
+    Desktop: ./tests/unittest.sh tests/test_appearance_manager.py
+    Device:  ./tests/unittest.sh tests/test_appearance_manager.py --ondevice
+"""
+
+import os
+import unittest
+
+from mpos import AppearanceManager, SharedPreferences
+
+
+class TestAppearanceManagerPrefs(unittest.TestCase):
+
+    APP_ID = "com.test.appearance_manager"
+    FILEPATH = "data/com.test.appearance_manager/config.json"
+
+    def setUp(self):
+        # Scrub any leftover prefs from previous runs so get_string()
+        # observations reflect only what this test writes.
+        self._remove(self.FILEPATH)
+        # Snapshot AppearanceManager state so a test that flips light_mode
+        # doesn't leak into the next test.
+        self._saved_is_light = AppearanceManager.is_light_mode()
+        self._saved_primary = AppearanceManager.get_primary_color()
+
+    def tearDown(self):
+        self._remove(self.FILEPATH)
+        # Best-effort restore.
+        AppearanceManager._is_light_mode = self._saved_is_light
+        AppearanceManager._primary_color = self._saved_primary
+
+    def _remove(self, path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    # ---- set_light_mode --------------------------------------------------
+
+    def test_set_light_mode_dark_persists(self):
+        prefs = SharedPreferences(self.APP_ID)
+        AppearanceManager.set_light_mode(False, prefs)
+        self.assertEqual(prefs.get_string("theme_light_dark"), "dark")
+        self.assertFalse(AppearanceManager.is_light_mode())
+
+    def test_set_light_mode_light_persists(self):
+        prefs = SharedPreferences(self.APP_ID)
+        AppearanceManager.set_light_mode(True, prefs)
+        self.assertEqual(prefs.get_string("theme_light_dark"), "light")
+        self.assertTrue(AppearanceManager.is_light_mode())
+
+    def test_set_light_mode_without_prefs_updates_memory_only(self):
+        # Without a prefs arg the method must not raise and must still update
+        # the in-memory flag, matching the documented "prefs optional" signature.
+        AppearanceManager.set_light_mode(False)
+        self.assertFalse(AppearanceManager.is_light_mode())
+        AppearanceManager.set_light_mode(True)
+        self.assertTrue(AppearanceManager.is_light_mode())
+
+    # ---- set_primary_color -----------------------------------------------
+
+    def test_set_primary_color_persists_hex_string(self):
+        prefs = SharedPreferences(self.APP_ID)
+        AppearanceManager.set_primary_color(0xFF5722, prefs)
+        self.assertEqual(prefs.get_string("theme_primary_color"), "0xFF5722")
+
+    def test_set_primary_color_non_int_does_not_persist(self):
+        # The method only persists when the colour is an int; anything else
+        # (e.g. an lv.color_t) just updates the in-memory value. It must not
+        # raise either way.
+        prefs = SharedPreferences(self.APP_ID)
+        try:
+            AppearanceManager.set_primary_color("not-an-int", prefs)
+        except Exception as e:
+            self.fail("set_primary_color raised for non-int colour: %r" % e)
+        # Key wasn't written, so get_string returns the explicit default.
+        self.assertEqual(
+            prefs.get_string("theme_primary_color", "__unset__"),
+            "__unset__",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
\`AppearanceManager.set_light_mode(is_light, prefs)\` and \`set_primary_color(color, prefs)\` both call \`prefs.set_string(key, value)\`, a method that does not exist on \`SharedPreferences\`. Writes must go through \`prefs.edit().put_string(key, value).commit()\` (see \`lib/mpos/config.py\`).

## Runtime behaviour today

| Call | Result |
|---|---|
| \`set_light_mode(True, prefs)\` | \`AttributeError: 'SharedPreferences' object has no attribute 'set_string'\` |
| \`set_light_mode(True, None)\` | Sets only the in-memory \`_is_light_mode\` flag; LVGL theme is not reinitialised |
| \`set_primary_color(0x123456, prefs)\` | Same \`AttributeError\` |
| \`set_primary_color(0x123456, None)\` | Sets \`_primary_color\` but does not reinitialise the theme, so the colour isn't applied |

So the documented public API is effectively a no-op or raises; it has never worked since \`AppearanceManager\` was added.

## Why it wasn't caught

No code inside \`internal_filesystem/\` calls these setters. The built-in settings app (\`builtin/apps/com.micropythonos.settings/assets/settings.py\`) uses the \`\"ui\": \"radiobuttons\"\` settings framework for persistence and then calls \`AppearanceManager.init(self.prefs)\` from a \`changed_callback\`. Third-party apps following the docstring examples (e.g. a displaywallet I was working on) hit the bug.

## The fix
- Swap \`prefs.set_string(key, value)\` for \`prefs.edit().put_string(key, value).commit()\` in both methods.
- Merge the two \`if prefs:\` branches in \`set_light_mode\` so \`cls.init(prefs)\` is called **after** the save succeeds (previously the second branch was unreachable in the \`prefs\` path because the first always raised).
- Call \`cls.init(prefs)\` from \`set_primary_color\` too — previously it only mutated the in-memory class attr and never reinitialised the LVGL theme, so visually nothing changed even if the save had worked.

Diff is ~13 lines.

## Before / after (behavioural)

**Before:**
\`\`\`python
AppearanceManager.set_light_mode(False, prefs)
# -> AttributeError: 'SharedPreferences' object has no attribute 'set_string'
\`\`\`

**After:**
\`\`\`python
AppearanceManager.set_light_mode(False, prefs)
# -> prefs['theme_light_dark'] = 'dark' on disk
# -> LVGL theme reinitialised in dark mode
# -> [AppearanceManager] Initialized: light_mode=False, ...
\`\`\`

## Verification
- Confirmed the same fixed code pattern works on a real device by using it directly in a third-party app before landing this PR.
- No callers inside MicroPythonOS need changes (none were using the broken methods).

## Related
Third-party impact surfaced during https://github.com/LightningPiggy/LightningPiggyApp/pull/27 (theme toggle in Lightning Piggy), which currently works around the bug by calling \`edit().put_string().commit()\` directly. After this PR, that workaround can be simplified.