### PR TITLE
Add unit tests for Lightning Piggy app (onchain, per-slot cache, theme override)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ OS:
 - Fri3d 2024: add support for IR remote app
 - Fri3d 2026: add support for IR remote app
 
-Tests:
-- Add unit tests for Lightning Piggy app: on-chain wallet (OnchainWallet parsers + constructor validation), per-slot wallet_cache, and app-local theme override (_AppThemeView)
-
 
 0.9.2
 =====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ OS:
 - Fri3d 2024: add support for IR remote app
 - Fri3d 2026: add support for IR remote app
 
+Tests:
+- Add unit tests for Lightning Piggy app: on-chain wallet (OnchainWallet parsers + constructor validation), per-slot wallet_cache, and app-local theme override (_AppThemeView)
+
 
 0.9.2
 =====

--- a/tests/test_displaywallet_theme_override.py
+++ b/tests/test_displaywallet_theme_override.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for the app-local theme override helper in the Lightning Piggy app.
+
+Targets LightningPiggyApp PR #27 (app-local Light/Dark theme toggle). The
+override lives in the app's own prefs under `theme_override`; if set, it
+takes precedence over the OS-level theme but never writes to OS prefs.
+
+This test covers the `_AppThemeView` adapter class that feeds
+AppearanceManager.init() a synthesised prefs view (override value + OS
+primary color) without touching OS prefs on disk.
+
+Usage:
+    Desktop: ./tests/unittest.sh tests/test_displaywallet_theme_override.py
+    Device:  ./tests/unittest.sh tests/test_displaywallet_theme_override.py --ondevice
+"""
+
+import sys
+import unittest
+
+sys.path.append("apps/com.lightningpiggy.displaywallet/assets/")
+
+# The _AppThemeView class is defined at module-level in displaywallet.py.
+# Importing displaywallet pulls in LVGL+SettingsActivity machinery which is
+# heavy/noisy, but it works in the test harness. If the feature isn't landed
+# yet, _AppThemeView won't exist and the tests skip gracefully.
+try:
+    import displaywallet
+    _HAVE_APP_THEME_VIEW = hasattr(displaywallet, "_AppThemeView")
+except Exception:
+    _HAVE_APP_THEME_VIEW = False
+
+
+@unittest.skipUnless(_HAVE_APP_THEME_VIEW, "_AppThemeView not installed (PR #27 not landed)")
+class TestAppThemeView(unittest.TestCase):
+    """The `_AppThemeView` duck-type mimics the `SharedPreferences.get_string`
+    surface needed by `AppearanceManager.init()`, so the theme can be
+    reinitialised with an app-local override without touching OS prefs."""
+
+    def test_returns_stored_theme_light_dark(self):
+        v = displaywallet._AppThemeView("dark", "0x1234AB")
+        self.assertEqual(v.get_string("theme_light_dark"), "dark")
+
+    def test_returns_stored_primary_color(self):
+        v = displaywallet._AppThemeView("light", "0xABCDEF")
+        self.assertEqual(v.get_string("theme_primary_color"), "0xABCDEF")
+
+    def test_unknown_key_returns_default(self):
+        v = displaywallet._AppThemeView("dark", "0x123456")
+        self.assertEqual(v.get_string("unrelated_key", "fallback"), "fallback")
+        # And None default when no default provided
+        self.assertIsNone(v.get_string("unrelated_key"))
+
+    def test_does_not_expose_set_or_edit(self):
+        # The view intentionally exposes only get_string — AppearanceManager.init
+        # reads from it and shouldn't try to write. Missing setters would be a
+        # regression.
+        v = displaywallet._AppThemeView("light", "0x000000")
+        self.assertFalse(hasattr(v, "set_string"))
+        self.assertFalse(hasattr(v, "edit"))
+
+
+@unittest.skipUnless(_HAVE_APP_THEME_VIEW, "_AppThemeView not installed")
+class TestAppThemeViewIntegrationWithAppearanceManager(unittest.TestCase):
+    """Once PR #120 lands, AppearanceManager.init() uses edit/put_string/commit
+    on its prefs arg when called from the setters — but *not* from init() itself,
+    which only reads via get_string. So an _AppThemeView (read-only) is
+    compatible with init() even though it has no edit() method."""
+
+    def test_init_reads_from_view_without_writing(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            v = displaywallet._AppThemeView("dark", "0xF0A010")
+            # Must not raise, must not attempt to write.
+            AppearanceManager.init(v)
+            self.assertFalse(AppearanceManager.is_light_mode())
+
+            v = displaywallet._AppThemeView("light", "0xF0A010")
+            AppearanceManager.init(v)
+            self.assertTrue(AppearanceManager.is_light_mode())
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_displaywallet_theme_override.py
+++ b/tests/test_displaywallet_theme_override.py
@@ -82,5 +82,87 @@ class TestAppThemeViewIntegrationWithAppearanceManager(unittest.TestCase):
             AppearanceManager._is_light_mode = saved
 
 
+_HAVE_APPLY_SCREEN_THEME = _HAVE_APP_THEME_VIEW and hasattr(displaywallet, "_apply_screen_theme") if _HAVE_APP_THEME_VIEW else False
+
+
+@unittest.skipUnless(_HAVE_APPLY_SCREEN_THEME, "_apply_screen_theme not installed")
+class TestApplyScreenTheme(unittest.TestCase):
+    """`_apply_screen_theme(screen)` forces an explicit bg colour that matches
+    the app's main display — pure black in dark mode, pure white in light mode.
+    MUST set both directions: once an explicit style is set it overrides LVGL's
+    default-theme bg, so a dark→light toggle would leave a lingering black bg
+    if we only set black."""
+
+    class _RecordingScreen:
+        """Minimal screen stub that records the last `set_style_bg_color` call."""
+        def __init__(self):
+            self.last_color = None
+            self.last_part = None
+            self.calls = 0
+
+        def set_style_bg_color(self, color, part):
+            self.last_color = color
+            self.last_part = part
+            self.calls += 1
+
+    def _force_mode(self, is_light):
+        from mpos import AppearanceManager
+        AppearanceManager._is_light_mode = bool(is_light)
+
+    def test_dark_mode_sets_black_bg(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            self._force_mode(False)
+            import lvgl as lv
+            screen = self._RecordingScreen()
+            displaywallet._apply_screen_theme(screen)
+            # Compare underlying 0xRRGGBB int because LVGL color_t objects
+            # don't implement __eq__ across all builds.
+            self.assertEqual(screen.calls, 1)
+            self.assertEqual(screen.last_part, lv.PART.MAIN)
+            # color_black == 0x000000
+            self.assertEqual(screen.last_color.full if hasattr(screen.last_color, 'full') else None,
+                             lv.color_black().full if hasattr(lv.color_black(), 'full') else None)
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+    def test_light_mode_sets_white_bg(self):
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            self._force_mode(True)
+            import lvgl as lv
+            screen = self._RecordingScreen()
+            displaywallet._apply_screen_theme(screen)
+            self.assertEqual(screen.calls, 1)
+            self.assertEqual(screen.last_part, lv.PART.MAIN)
+            self.assertEqual(screen.last_color.full if hasattr(screen.last_color, 'full') else None,
+                             lv.color_white().full if hasattr(lv.color_white(), 'full') else None)
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+    def test_applies_in_both_directions(self):
+        """Regression: if only dark mode set a bg, a dark→light flip leaves the
+        black style lingering on screen. Guard that BOTH branches write."""
+        from mpos import AppearanceManager
+        saved = AppearanceManager.is_light_mode()
+        try:
+            screen = self._RecordingScreen()
+
+            self._force_mode(False)
+            displaywallet._apply_screen_theme(screen)
+            dark_count = screen.calls
+
+            self._force_mode(True)
+            displaywallet._apply_screen_theme(screen)
+            light_count = screen.calls
+
+            self.assertEqual(dark_count, 1, "dark mode should set bg once")
+            self.assertEqual(light_count, 2, "light mode should also set bg (not skip)")
+        finally:
+            AppearanceManager._is_light_mode = saved
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_onchain_wallet.py
+++ b/tests/test_onchain_wallet.py
@@ -1,0 +1,178 @@
+"""
+Unit tests for the on-chain wallet type in the Lightning Piggy app.
+
+Targets LightningPiggyApp PR #25 (on-chain wallet via Blockbook).
+
+Usage:
+    Desktop: ./tests/unittest.sh tests/test_onchain_wallet.py
+    Device:  ./tests/unittest.sh tests/test_onchain_wallet.py --ondevice
+"""
+
+import sys
+import unittest
+
+sys.path.append("apps/com.lightningpiggy.displaywallet/assets/")
+
+try:
+    from onchain_wallet import OnchainWallet
+    _HAVE_ONCHAIN = True
+except ImportError:
+    _HAVE_ONCHAIN = False
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed (feature not landed yet)")
+class TestOnchainWalletConstructor(unittest.TestCase):
+
+    def test_rejects_empty_xpub(self):
+        with self.assertRaises(ValueError):
+            OnchainWallet("")
+
+    def test_rejects_bad_prefix(self):
+        with self.assertRaises(ValueError):
+            OnchainWallet("foobarbaz")
+
+    def test_accepts_xpub_prefix(self):
+        w = OnchainWallet("xpub1234example")
+        self.assertEqual(w.xpub, "xpub1234example")
+
+    def test_accepts_zpub_prefix(self):
+        w = OnchainWallet("zpub1234example")
+        self.assertEqual(w.xpub, "zpub1234example")
+
+    def test_trims_blockbook_trailing_slash(self):
+        w = OnchainWallet("zpub1234example", blockbook_url="https://example.com/")
+        self.assertEqual(w.blockbook_url, "https://example.com")
+
+    def test_blockbook_url_default_when_none(self):
+        w = OnchainWallet("zpub1234example")
+        self.assertEqual(w.blockbook_url, OnchainWallet.DEFAULT_BLOCKBOOK_URL)
+
+    def test_blockbook_url_empty_falls_back_to_default(self):
+        # An empty string URL pref should behave the same as None.
+        w = OnchainWallet("zpub1234example", blockbook_url=None)
+        self.assertEqual(w.blockbook_url, OnchainWallet.DEFAULT_BLOCKBOOK_URL)
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed")
+class TestOnchainWalletParseTransactions(unittest.TestCase):
+
+    def setUp(self):
+        self.w = OnchainWallet("zpub1234example")
+
+    def test_confirmed_incoming_tx(self):
+        txs = [{
+            "txid": "abc", "confirmations": 5, "blockTime": 1775838000,
+            "vin": [{"isOwn": False, "value": "10000"}],
+            "vout": [{"isOwn": True, "value": "6884"}, {"isOwn": False, "value": "3000"}],
+        }]
+        payments, any_unconfirmed = self.w._parse_transactions(txs)
+        self.assertEqual(len(payments), 1)
+        p = list(payments)[0]
+        self.assertEqual(p.amount_sats, 6884)
+        self.assertIn("confirmed", p.comment)
+        self.assertFalse(any_unconfirmed)
+
+    def test_unconfirmed_tx_flagged(self):
+        txs = [{
+            "txid": "pending", "confirmations": 0, "blockTime": 0,
+            "vin": [{"isOwn": False, "value": "10000"}],
+            "vout": [{"isOwn": True, "value": "5000"}],
+        }]
+        _payments, any_unconfirmed = self.w._parse_transactions(txs)
+        self.assertTrue(any_unconfirmed)
+
+    def test_self_transfer_is_fee_only(self):
+        # All inputs + all outputs marked isOwn → classic self-transfer: the
+        # wallet loses only the network fee.
+        txs = [{
+            "txid": "self", "confirmations": 10, "blockTime": 1775838000, "fees": "500",
+            "vin": [{"isOwn": True, "value": "50500"}],
+            "vout": [{"isOwn": True, "value": "50000"}],
+        }]
+        payments, _unc = self.w._parse_transactions(txs)
+        p = list(payments)[0]
+        self.assertEqual(p.amount_sats, -500)
+        self.assertIn("self-transfer", p.comment)
+
+    def test_outgoing_tx_uses_net_amount(self):
+        # Our input 20000, our output 15000 (change) → net -5000 sent.
+        txs = [{
+            "txid": "out", "confirmations": 3, "blockTime": 1775838000, "fees": "200",
+            "vin": [{"isOwn": True, "value": "20000"}],
+            "vout": [
+                {"isOwn": True, "value": "15000"},      # change back to us
+                {"isOwn": False, "value": "4800"},      # paid out to someone else
+            ],
+        }]
+        payments, _unc = self.w._parse_transactions(txs)
+        p = list(payments)[0]
+        # Net = 15000 - 20000 = -5000 (it goes through the non-self-transfer branch
+        # because not all vout is isOwn).
+        self.assertEqual(p.amount_sats, -5000)
+
+    def test_empty_transactions(self):
+        payments, any_unconfirmed = self.w._parse_transactions([])
+        self.assertEqual(len(payments), 0)
+        self.assertFalse(any_unconfirmed)
+
+    def test_none_transactions(self):
+        # Response may legitimately have no "transactions" key.
+        payments, any_unconfirmed = self.w._parse_transactions(None)
+        self.assertEqual(len(payments), 0)
+        self.assertFalse(any_unconfirmed)
+
+
+@unittest.skipUnless(_HAVE_ONCHAIN, "onchain_wallet.py not installed")
+class TestOnchainWalletPickReceiveAddress(unittest.TestCase):
+
+    def setUp(self):
+        self.w = OnchainWallet("zpub1234example")
+
+    def test_picks_first_unused_external(self):
+        tokens = [
+            {"name": "bc1qused1", "path": "m/84'/0'/0'/0/0", "transfers": 3},
+            {"name": "bc1qfirst", "path": "m/84'/0'/0'/0/5", "transfers": 0},
+            {"name": "bc1qsecond", "path": "m/84'/0'/0'/0/6", "transfers": 0},
+        ]
+        self.assertEqual(
+            self.w._pick_receive_address(tokens),
+            "bitcoin:bc1qfirst",
+        )
+
+    def test_skips_change_chain(self):
+        tokens = [
+            {"name": "bc1qchange", "path": "m/84'/0'/0'/1/0", "transfers": 0},  # internal/change
+            {"name": "bc1qexternal", "path": "m/84'/0'/0'/0/0", "transfers": 0},
+        ]
+        self.assertEqual(
+            self.w._pick_receive_address(tokens),
+            "bitcoin:bc1qexternal",
+        )
+
+    def test_skips_used_addresses(self):
+        tokens = [
+            {"name": "bc1qused1", "path": "m/84'/0'/0'/0/0", "transfers": 7},
+            {"name": "bc1qused2", "path": "m/84'/0'/0'/0/1", "transfers": 1},
+        ]
+        self.assertIsNone(self.w._pick_receive_address(tokens))
+
+    def test_none_when_no_tokens(self):
+        self.assertIsNone(self.w._pick_receive_address([]))
+        self.assertIsNone(self.w._pick_receive_address(None))
+
+    def test_returns_lowest_index_unused(self):
+        # Three unused external addresses — the one at index 1 must win
+        # regardless of list order, because it has the lowest derivation index.
+        tokens = [
+            {"name": "bc1qthird", "path": "m/84'/0'/0'/0/3", "transfers": 0},
+            {"name": "bc1qfirst", "path": "m/84'/0'/0'/0/1", "transfers": 0},
+            {"name": "bc1qsecond", "path": "m/84'/0'/0'/0/2", "transfers": 0},
+        ]
+        self.assertEqual(
+            self.w._pick_receive_address(tokens),
+            "bitcoin:bc1qfirst",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wallet_cache_per_slot.py
+++ b/tests/test_wallet_cache_per_slot.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for the per-slot wallet_cache in the Lightning Piggy app.
+
+Targets LightningPiggyApp PR #26 (multi-wallet). Slot 1 keeps the
+unsuffixed cache keys for back-compat; slot 2 mirrors them with a `_2`
+suffix so both wallets can be cached side-by-side and swapping between
+them repaints instantly without waiting for the network.
+
+Usage:
+    Desktop: ./tests/unittest.sh tests/test_wallet_cache_per_slot.py
+    Device:  ./tests/unittest.sh tests/test_wallet_cache_per_slot.py --ondevice
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append("apps/com.lightningpiggy.displaywallet/assets/")
+
+try:
+    import wallet_cache
+    from payment import Payment
+    from unique_sorted_list import UniqueSortedList
+    # Detect per-slot support by probing: pre-PR-#26 versions reject `slot=`.
+    # MicroPython doesn't include inspect.signature, hence the direct probe.
+    try:
+        wallet_cache.save_cache(slot=1)  # no-op call — no fields provided
+        _HAVE_PER_SLOT = True
+    except TypeError:
+        _HAVE_PER_SLOT = False
+except ImportError:
+    _HAVE_PER_SLOT = False
+
+
+CACHE_FILE = "data/com.lightningpiggy.displaywallet/cache.json"
+
+
+def _remove(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+@unittest.skipUnless(_HAVE_PER_SLOT, "wallet_cache per-slot support not installed (PR #26 not landed)")
+class TestWalletCachePerSlot(unittest.TestCase):
+
+    def setUp(self):
+        # Scrub any on-disk cache state from previous runs.
+        _remove(CACHE_FILE)
+        # The module-level _cache object loaded from disk at import; reset its
+        # in-memory dict too so we start each test with a blank slate.
+        wallet_cache._cache.data = {}
+
+    def tearDown(self):
+        _remove(CACHE_FILE)
+        wallet_cache._cache.data = {}
+
+    # ---- balance -----------------------------------------------------
+
+    def test_slot_1_uses_unsuffixed_keys_back_compat(self):
+        wallet_cache.save_cache(balance=3113, slot=1)
+        self.assertEqual(wallet_cache._cache.data.get("balance"), 3113)
+        self.assertFalse("balance_2" in wallet_cache._cache.data)
+
+    def test_slot_2_uses_suffixed_keys(self):
+        wallet_cache.save_cache(balance=6884, slot=2)
+        self.assertEqual(wallet_cache._cache.data.get("balance_2"), 6884)
+        self.assertFalse("balance" in wallet_cache._cache.data)
+
+    def test_both_slots_coexist_without_clobbering(self):
+        wallet_cache.save_cache(balance=3113, slot=1)
+        wallet_cache.save_cache(balance=6884, slot=2)
+        self.assertEqual(wallet_cache.load_cached_balance(slot=1), 3113)
+        self.assertEqual(wallet_cache.load_cached_balance(slot=2), 6884)
+
+    def test_slot_default_is_1(self):
+        # Pre-PR-#26 callers passed no slot arg; they should still target slot 1.
+        wallet_cache.save_cache(balance=42)
+        self.assertEqual(wallet_cache.load_cached_balance(), 42)
+        self.assertEqual(wallet_cache.load_cached_balance(slot=1), 42)
+        self.assertIsNone(wallet_cache.load_cached_balance(slot=2))
+
+    # ---- static_receive_code -----------------------------------------
+
+    def test_static_receive_code_per_slot(self):
+        wallet_cache.save_cache(static_receive_code="LNURL1...", slot=1)
+        wallet_cache.save_cache(static_receive_code="bitcoin:bc1q...", slot=2)
+        self.assertEqual(wallet_cache.load_cached_static_receive_code(slot=1), "LNURL1...")
+        self.assertEqual(wallet_cache.load_cached_static_receive_code(slot=2), "bitcoin:bc1q...")
+
+    # ---- payments ----------------------------------------------------
+
+    def test_payments_round_trip_per_slot(self):
+        p1 = Payment(1000, 199, "lnbits memo")
+        p2 = Payment(2000, 6884, "Apr 9 confirmed")
+        slot1_list = UniqueSortedList()
+        slot1_list.add(p1)
+        slot2_list = UniqueSortedList()
+        slot2_list.add(p2)
+        wallet_cache.save_cache(payments=slot1_list, slot=1)
+        wallet_cache.save_cache(payments=slot2_list, slot=2)
+
+        out1 = wallet_cache.load_cached_payments(slot=1)
+        out2 = wallet_cache.load_cached_payments(slot=2)
+        self.assertEqual(len(out1), 1)
+        self.assertEqual(len(out2), 1)
+        self.assertEqual(list(out1)[0].comment, "lnbits memo")
+        self.assertEqual(list(out2)[0].comment, "Apr 9 confirmed")
+
+    # ---- None-when-empty ---------------------------------------------
+
+    def test_load_returns_none_when_not_set(self):
+        self.assertIsNone(wallet_cache.load_cached_balance(slot=1))
+        self.assertIsNone(wallet_cache.load_cached_balance(slot=2))
+        self.assertIsNone(wallet_cache.load_cached_payments(slot=1))
+        self.assertIsNone(wallet_cache.load_cached_payments(slot=2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds focused unit tests for the three open Lightning Piggy PRs
([#25](https://github.com/LightningPiggy/LightningPiggyApp/pull/25),
[#26](https://github.com/LightningPiggy/LightningPiggyApp/pull/26),
[#27](https://github.com/LightningPiggy/LightningPiggyApp/pull/27))
— on-chain wallet via Blockbook, multi-wallet with per-slot cache, and app-local Light/Dark theme override.

These land as a separate PR against MicroPythonOS because \`tests/\` lives here; the Lightning Piggy PRs themselves are in the \`LightningPiggyApp\` repo.

## Files
| File | Scope |
|---|---|
| \`tests/test_onchain_wallet.py\` | 18 tests — OnchainWallet constructor validation, \`_parse_transactions\` (confirmed / unconfirmed / self-transfer / outgoing net), \`_pick_receive_address\` (skip change chain, skip used, lowest-index-unused) |
| \`tests/test_wallet_cache_per_slot.py\` | 7 tests — slot=1 keeps unsuffixed keys (back-compat), slot=2 uses \`_2\` suffix, both coexist, default slot is 1, static_receive_code + payments round-trip per slot |
| \`tests/test_displaywallet_theme_override.py\` | 5 tests — \`_AppThemeView\` exposes only \`get_string\`, returns stored values + defaults, integrates with \`AppearanceManager.init\` without triggering any writes |

## Graceful skipping

Each test file wraps imports in \`try/except ImportError\` and uses \`@unittest.skipUnless\` so tests skip gracefully when the corresponding LightningPiggyApp feature hasn't landed yet. The skips auto-resolve when the Lightning Piggy PR merges and the symlinked app source picks up the feature.

Behaviour matrix observed locally:

| LightningPiggyApp branch | \`test_onchain_wallet\` | \`test_wallet_cache_per_slot\` | \`test_theme_override\` |
|---|---|---|---|
| \`feature/onchain-wallet\` | **18 pass** | skip | skip |
| \`feature/multi-wallet\` | **18 pass** | **7 pass** | skip |
| \`feature/theme-toggle\` | skip | skip | **5 pass** |
| \`master\` (none landed) | skip | skip | skip |

## Merge checklist compliance
- [x] CHANGELOG.md "Future release" updated with a Tests section
- [x] No app version bump needed (tests only)
- [x] No framework doc changes (tests only)
- [x] No MAINTAINERS change
- [x] No setting definition changes
- [x] Adds unit tests ✓
- [x] Non-functional (test-only) change kept to its own PR

## Related
- Depends on the symlink \`internal_filesystem/apps/com.lightningpiggy.displaywallet → ../LightningPiggyApp/com.lightningpiggy.displaywallet\` already in \`main\`
- Pairs with upstream PR #120 (fix AppearanceManager \`prefs.set_string\`) which shares the same \`tests/unittest.sh\` harness