### PR TITLE
Implement support for Freenove's ESP32-S3 display board

### DIFF
--- a/internal_filesystem/lib/drivers/codec/es8311.py
+++ b/internal_filesystem/lib/drivers/codec/es8311.py
@@ -46,6 +46,7 @@ _REG13_SYS      = const(0x13)  # system: enable HP output driver
 _REG14_MIC      = const(0x14)  # microphone: DMIC select, analog PGA gain
 _REG17_ADC_VOL  = const(0x17)  # ADC volume / gain
 _REG1C_ADC_EQ   = const(0x1C)  # ADC equalizer bypass + DC-offset cancel
+_REG31_DAC_MUTE = const(0x31)  # DAC soft-mute control (bits[6:5] = 11 → muted)
 _REG32_DAC_VOL  = const(0x32)  # DAC output volume (0x00=muted, 0xFF=max)
 _REG37_DAC_EQ   = const(0x37)  # DAC equalizer / ramp-rate control
 
@@ -123,7 +124,27 @@ class ES8311:
         self._wr(_REG32_DAC_VOL, _DEFAULT_VOL_REG)  # set output volume (~85%)
         self._wr(_REG37_DAC_EQ,  0x08)              # bypass DAC equalizer
 
+        # Soft-mute the DAC at boot — unmuted by on_open callback when playback starts
+        self.dac_mute(True)
+
         print("ES8311: codec initialised")
+
+    def dac_mute(self, mute=True):
+        """
+        Soft-mute or unmute the DAC output.
+
+        Uses the ES8311's built-in ramp so the transition is pop-free.
+        Does not affect the DAC power state or volume register.
+
+        Args:
+            mute: True to mute, False to unmute
+        """
+        val = self._rd(_REG31_DAC_MUTE)
+        if mute:
+            val |= 0x60   # bits[6:5] = 11 → soft mute on
+        else:
+            val &= ~0x60  # bits[6:5] = 00 → soft mute off
+        self._wr(_REG31_DAC_MUTE, val)
 
     def set_dac_volume(self, percent):
         """

--- a/internal_filesystem/lib/drivers/codec/es8311.py
+++ b/internal_filesystem/lib/drivers/codec/es8311.py
@@ -44,6 +44,7 @@ _REG0E_SYS      = const(0x0E)  # system: enable analog PGA + ADC modulator
 _REG12_DAC_EN   = const(0x12)  # system: power-up DAC
 _REG13_SYS      = const(0x13)  # system: enable HP output driver
 _REG14_MIC      = const(0x14)  # microphone: DMIC select, analog PGA gain
+_REG16_ADC_GAIN = const(0x16)  # ADC digital gain (separate from volume; default 4 = 24 dB)
 _REG17_ADC_VOL  = const(0x17)  # ADC volume / gain
 _REG1C_ADC_EQ   = const(0x1C)  # ADC equalizer bypass + DC-offset cancel
 _REG31_DAC_MUTE = const(0x31)  # DAC soft-mute control (bits[6:5] = 11 → muted)
@@ -117,6 +118,7 @@ class ES8311:
         self._wr(_REG14_MIC,    0x1A)   # enable analog mic input, max PGA gain
 
         # --- ADC (microphone) ---
+        self._wr(_REG16_ADC_GAIN, 0x04)  # ADC digital gain = 24 dB (default)
         self._wr(_REG17_ADC_VOL, 0xC8)  # ADC gain/volume (Espressif default)
         self._wr(_REG1C_ADC_EQ,  0x6A)  # ADC equalizer bypass, cancel DC offset
 

--- a/internal_filesystem/lib/drivers/codec/es8311.py
+++ b/internal_filesystem/lib/drivers/codec/es8311.py
@@ -1,0 +1,168 @@
+# ES8311 mono audio codec driver
+# Initialises the ES8311 over I2C so that the ESP32 I2S peripheral can route
+# audio to/from the on-board speaker/microphone.
+#
+# The codec must be configured once at boot (before any I2S TX/RX session).
+# It does NOT need to be re-initialised per session; the same divider values
+# are valid for every sample rate because MCLK is always supplied as
+# 256 × sample_rate by the caller (PWM or I2S MCK pin).
+#
+# Clock maths (MCLK_MULTIPLE = 256, bits-per-slot = 16, two slots per frame):
+#   BCLK    = sample_rate × 2 × 16 = sample_rate × 32
+#   SCLKDIV = MCLK / BCLK          = 256 × SR   / (32 × SR) = 8
+#   LRCKDIV = MCLK / LRCK          = 256 × SR   / SR        = 256 = 0x100
+# → REG03 = 8, REG04 = 0x01, REG05 = 0x00 — constant for all sample rates.
+#
+# The codec is configured as I2S slave (ESP32 drives BCLK and LRCK).
+# I2S format: standard I2S, 16-bit word length.
+# Microphone input: single-ended analogue (MIC1P/MIC1N differential pair).
+# Speaker output:   mono analogue line output via built-in HP driver.
+
+import time
+
+try:
+    from micropython import const
+except ImportError:
+    def const(x): return x
+
+I2C_ADDR = const(0x18)
+
+# ---------------------------------------------------------------------------
+# Register addresses (from ES8311 datasheet)
+# ---------------------------------------------------------------------------
+_REG_RESET         = const(0x00)
+_REG_CLK1          = const(0x01)
+_REG_CLK2          = const(0x02)
+_REG_CLK3          = const(0x03)  # SCLKDIV (MCLK→BCLK divider)
+_REG_CLK4          = const(0x04)  # LRCKDIV high byte
+_REG_CLK5          = const(0x05)  # LRCKDIV low byte
+_REG_CLK6          = const(0x06)  # ADC oversampling clock
+_REG_CLK7          = const(0x07)  # DAC oversampling clock
+_REG_CLK8          = const(0x08)  # Clock enable mask
+_REG_SDPIN         = const(0x09)  # ADC serial data format (I2S slave → codec RX)
+_REG_SDPOUT        = const(0x0A)  # DAC serial data format (codec TX → I2S master)
+_REG_SYSTEM0D      = const(0x0D)
+_REG_SYSTEM0E      = const(0x0E)
+_REG_SYSTEM0F      = const(0x0F)
+_REG_SYSTEM10      = const(0x10)  # VSEL (reference voltage)
+_REG_SYSTEM11      = const(0x11)
+_REG_SYSTEM12      = const(0x12)  # Microphone bias
+_REG_SYSTEM13      = const(0x13)
+_REG_SYSTEM14      = const(0x14)  # ADC power and MIC input mux
+_REG_ADC1          = const(0x17)  # ADC power / PGA gain
+_REG_ADC2          = const(0x18)
+_REG_ADC3          = const(0x19)  # ADC high-pass filter
+_REG_ADC_VOL       = const(0x1A)  # ADC digital volume (0x00 = 0 dB)
+_REG_ADC5          = const(0x1B)
+_REG_ADC6          = const(0x1C)  # ALC / noise-gate control
+_REG_DAC1          = const(0x32)  # DAC power
+_REG_DAC2          = const(0x33)  # DAC output mixer / HP driver
+_REG_DAC3          = const(0x34)
+_REG_DAC4          = const(0x35)
+_REG_DAC_VOL       = const(0x37)  # DAC digital volume (0x00 = 0 dB, 0xFF = −96 dB)
+_REG_ANALOG_PWR    = const(0x45)  # Analogue power management
+
+# ---------------------------------------------------------------------------
+# _CLK1: MCLK from external pin, clocks enabled, no pre-divider, no doubler
+# _SDPIN / _SDPOUT: slave mode, 16-bit word length, standard I2S format
+# ---------------------------------------------------------------------------
+_CLK1_MCLK_FROM_PIN = const(0x30)  # ENCLK=1, CLK_CPU_EN=1, MCLKDIV=÷1
+_I2S_16BIT_SLAVE    = const(0x0C)  # MASTER=0, WL[2:0]=011 (16-bit), FMT=I2S
+_VOL_REG_MAX_ATTEN  = const(0xBF)  # register value that gives maximum attenuation (~−96 dB)
+
+
+class ES8311:
+    """
+    Minimal ES8311 codec initialiser.
+
+    Usage::
+
+        i2c = machine.I2C(0, sda=Pin(16), scl=Pin(15), freq=400_000)
+        codec = ES8311(i2c)
+    """
+
+    def __init__(self, i2c):
+        self._i2c = i2c
+        self._init()
+
+    # ------------------------------------------------------------------
+    def _wr(self, reg, val):
+        self._i2c.writeto_mem(I2C_ADDR, reg, bytes([val]))
+
+    def _rd(self, reg):
+        buf = bytearray(1)
+        self._i2c.readfrom_mem_into(I2C_ADDR, reg, buf)
+        return buf[0]
+
+    # ------------------------------------------------------------------
+    def _init(self):
+        # Reset then release
+        self._wr(_REG_RESET, 0x1F)
+        time.sleep_ms(20)
+        self._wr(_REG_RESET, 0x00)
+
+        # Clock configuration — fixed dividers, valid for all sample rates
+        # when MCLK = 256 × sample_rate (see module header).
+        self._wr(_REG_CLK1, _CLK1_MCLK_FROM_PIN)
+        self._wr(_REG_CLK2, 0x00)   # no pre-divider, no frequency doubler
+        self._wr(_REG_CLK3, 0x08)   # SCLKDIV = 8  → BCLK = MCLK / 8
+        self._wr(_REG_CLK4, 0x01)   # LRCKDIV = 0x0100 = 256  (high byte)
+        self._wr(_REG_CLK5, 0x00)   # LRCKDIV low byte
+        self._wr(_REG_CLK6, 0x03)   # ADC oversampling clock divider
+        self._wr(_REG_CLK7, 0x03)   # DAC oversampling clock divider
+        self._wr(_REG_CLK8, 0xFF)   # enable all internal clocks
+
+        # I2S serial data format: 16-bit standard I2S, slave mode
+        self._wr(_REG_SDPIN,  _I2S_16BIT_SLAVE)  # ADC (recording)
+        self._wr(_REG_SDPOUT, _I2S_16BIT_SLAVE)  # DAC (playback)
+
+        # System / power-up settings (from Espressif ES8311 reference driver)
+        self._wr(_REG_SYSTEM0D, 0x01)
+        self._wr(_REG_SYSTEM0E, 0x02)
+        self._wr(_REG_SYSTEM0F, 0x44)
+        self._wr(_REG_SYSTEM10, 0x1C)  # VSEL: reference voltage for 3.3 V supply
+        self._wr(_REG_SYSTEM11, 0x00)
+        self._wr(_REG_SYSTEM12, 0x02)  # enable MICBIAS for on-board microphone
+        self._wr(_REG_SYSTEM13, 0x10)
+        self._wr(_REG_SYSTEM14, 0x1A)  # power-up ADC; select MIC1 input
+
+        # ADC (microphone recording)
+        self._wr(_REG_ADC1,    0xBF)  # power on ADC, PGA gain enabled
+        self._wr(_REG_ADC2,    0x00)
+        self._wr(_REG_ADC3,    0x02)  # enable ADC high-pass filter
+        self._wr(_REG_ADC_VOL, 0x00)  # ADC digital volume: 0 dB
+        self._wr(_REG_ADC5,    0x00)
+        self._wr(_REG_ADC6,    0x6C)  # ALC off, noise gate off
+
+        # DAC (speaker playback)
+        self._wr(_REG_DAC1,    0x00)  # power on DAC
+        self._wr(_REG_DAC2,    0xBF)  # enable DAC output and HP driver
+        self._wr(_REG_DAC3,    0x00)
+        self._wr(_REG_DAC4,    0x00)
+        self._wr(_REG_DAC_VOL, 0x00)  # DAC digital volume: 0 dB
+
+        # Analogue power-up
+        self._wr(_REG_ANALOG_PWR, 0x00)
+
+        print("ES8311: codec initialised")
+
+    def set_dac_volume(self, percent):
+        """
+        Set DAC (playback) volume.
+
+        Args:
+            percent: 0 (mute) … 100 (0 dB, maximum)
+        """
+        # Linear mapping: 0% → _VOL_REG_MAX_ATTEN (≈ −96 dB), 100% → 0x00 (0 dB)
+        val = int((100 - max(0, min(100, percent))) * _VOL_REG_MAX_ATTEN // 100)
+        self._wr(_REG_DAC_VOL, val)
+
+    def set_adc_volume(self, percent):
+        """
+        Set ADC (recording) gain.
+
+        Args:
+            percent: 0 (mute) … 100 (0 dB, maximum)
+        """
+        val = int((100 - max(0, min(100, percent))) * _VOL_REG_MAX_ATTEN // 100)
+        self._wr(_REG_ADC_VOL, val)

--- a/internal_filesystem/lib/drivers/codec/es8311.py
+++ b/internal_filesystem/lib/drivers/codec/es8311.py
@@ -2,21 +2,19 @@
 # Initialises the ES8311 over I2C so that the ESP32 I2S peripheral can route
 # audio to/from the on-board speaker/microphone.
 #
-# The codec must be configured once at boot (before any I2S TX/RX session).
-# It does NOT need to be re-initialised per session; the same divider values
-# are valid for every sample rate because MCLK is always supplied as
-# 256 × sample_rate by the caller (PWM or I2S MCK pin).
+# Register layout and initialisation sequence are taken directly from the
+# Espressif reference driver shipped with the Freenove ESP32-S3 Display
+# tutorial sketches (Sketch_07.1_Music / Sketch_07.2_Echo, es8311.cpp).
 #
-# Clock maths (MCLK_MULTIPLE = 256, bits-per-slot = 16, two slots per frame):
-#   BCLK    = sample_rate × 2 × 16 = sample_rate × 32
-#   SCLKDIV = MCLK / BCLK          = 256 × SR   / (32 × SR) = 8
-#   LRCKDIV = MCLK / LRCK          = 256 × SR   / SR        = 256 = 0x100
-# → REG03 = 8, REG04 = 0x01, REG05 = 0x00 — constant for all sample rates.
+# Clock configuration (MCLK_MULTIPLE = 256, 16-bit I2S, two slots per frame):
+#   MCLK   = sample_rate × 256  (driven by MCK PWM pin)
+#   BCLK   = MCLK / 4  (bclk_div = 4  → REG06 = bclk_div−1 = 3)
+#   LRCK   = MCLK / 256 = sample_rate  (lrck_h=0x00, lrck_l=0xFF → REG07/08)
+#   ADC/DAC oversampling rate = 0x10  (REG03 / REG04)
+# These divider values are identical for every standard sample rate when
+# MCLK = rate × 256 (verified against Espressif coeff_div[] table).
 #
-# The codec is configured as I2S slave (ESP32 drives BCLK and LRCK).
-# I2S format: standard I2S, 16-bit word length.
-# Microphone input: single-ended analogue (MIC1P/MIC1N differential pair).
-# Speaker output:   mono analogue line output via built-in HP driver.
+# The codec runs as I2S slave (ESP32-S3 drives BCLK and LRCK).
 
 import time
 
@@ -28,52 +26,39 @@ except ImportError:
 I2C_ADDR = const(0x18)
 
 # ---------------------------------------------------------------------------
-# Register addresses (from ES8311 datasheet)
+# Register addresses (from es8311_reg.h, Espressif reference driver)
 # ---------------------------------------------------------------------------
-_REG_RESET         = const(0x00)
-_REG_CLK1          = const(0x01)
-_REG_CLK2          = const(0x02)
-_REG_CLK3          = const(0x03)  # SCLKDIV (MCLK→BCLK divider)
-_REG_CLK4          = const(0x04)  # LRCKDIV high byte
-_REG_CLK5          = const(0x05)  # LRCKDIV low byte
-_REG_CLK6          = const(0x06)  # ADC oversampling clock
-_REG_CLK7          = const(0x07)  # DAC oversampling clock
-_REG_CLK8          = const(0x08)  # Clock enable mask
-_REG_SDPIN         = const(0x09)  # ADC serial data format (I2S slave → codec RX)
-_REG_SDPOUT        = const(0x0A)  # DAC serial data format (codec TX → I2S master)
-_REG_SYSTEM0D      = const(0x0D)
-_REG_SYSTEM0E      = const(0x0E)
-_REG_SYSTEM0F      = const(0x0F)
-_REG_SYSTEM10      = const(0x10)  # VSEL (reference voltage)
-_REG_SYSTEM11      = const(0x11)
-_REG_SYSTEM12      = const(0x12)  # Microphone bias
-_REG_SYSTEM13      = const(0x13)
-_REG_SYSTEM14      = const(0x14)  # ADC power and MIC input mux
-_REG_ADC1          = const(0x17)  # ADC power / PGA gain
-_REG_ADC2          = const(0x18)
-_REG_ADC3          = const(0x19)  # ADC high-pass filter
-_REG_ADC_VOL       = const(0x1A)  # ADC digital volume (0x00 = 0 dB)
-_REG_ADC5          = const(0x1B)
-_REG_ADC6          = const(0x1C)  # ALC / noise-gate control
-_REG_DAC1          = const(0x32)  # DAC power
-_REG_DAC2          = const(0x33)  # DAC output mixer / HP driver
-_REG_DAC3          = const(0x34)
-_REG_DAC4          = const(0x35)
-_REG_DAC_VOL       = const(0x37)  # DAC digital volume (0x00 = 0 dB, 0xFF = −96 dB)
-_REG_ANALOG_PWR    = const(0x45)  # Analogue power management
+_REG00_RESET    = const(0x00)  # reset + power control
+_REG01_CLK_SRC  = const(0x01)  # clock source select, all-clock enable
+_REG02_CLK_DIV  = const(0x02)  # pre-divider / pre-multiplier
+_REG03_ADC_OSR  = const(0x03)  # ADC fs-mode and oversampling rate
+_REG04_DAC_OSR  = const(0x04)  # DAC oversampling rate
+_REG05_CLKDIV   = const(0x05)  # ADC and DAC clock dividers
+_REG06_BCLKDIV  = const(0x06)  # BCLK (SCLK) inverter and divider
+_REG07_LRCK_H   = const(0x07)  # LRCK divider high byte
+_REG08_LRCK_L   = const(0x08)  # LRCK divider low byte
+_REG09_SDP_IN   = const(0x09)  # serial data port for DAC (playback input to codec)
+_REG0A_SDP_OUT  = const(0x0A)  # serial data port for ADC (recording output from codec)
+_REG0D_SYS      = const(0x0D)  # system: power-up analog circuitry
+_REG0E_SYS      = const(0x0E)  # system: enable analog PGA + ADC modulator
+_REG12_DAC_EN   = const(0x12)  # system: power-up DAC
+_REG13_SYS      = const(0x13)  # system: enable HP output driver
+_REG14_MIC      = const(0x14)  # microphone: DMIC select, analog PGA gain
+_REG17_ADC_VOL  = const(0x17)  # ADC volume / gain
+_REG1C_ADC_EQ   = const(0x1C)  # ADC equalizer bypass + DC-offset cancel
+_REG32_DAC_VOL  = const(0x32)  # DAC output volume (0x00=muted, 0xFF=max)
+_REG37_DAC_EQ   = const(0x37)  # DAC equalizer / ramp-rate control
 
-# ---------------------------------------------------------------------------
-# _CLK1: MCLK from external pin, clocks enabled, no pre-divider, no doubler
-# _SDPIN / _SDPOUT: slave mode, 16-bit word length, standard I2S format
-# ---------------------------------------------------------------------------
-_CLK1_MCLK_FROM_PIN = const(0x30)  # ENCLK=1, CLK_CPU_EN=1, MCLKDIV=÷1
-_I2S_16BIT_SLAVE    = const(0x0C)  # MASTER=0, WL[2:0]=011 (16-bit), FMT=I2S
-_VOL_REG_MAX_ATTEN  = const(0xBF)  # register value that gives maximum attenuation (~−96 dB)
+# SDP format word: slave mode (bit7=0), 16-bit resolution (bits[4:2]=011)
+_SDP_16BIT_SLAVE = const(0x0C)
+
+# Default DAC volume at init: 85% using Espressif formula (volume*256/100)−1
+_DEFAULT_VOL_REG = const(0xD8)  # = (85*256//100) - 1 ≈ 85% output volume
 
 
 class ES8311:
     """
-    Minimal ES8311 codec initialiser.
+    ES8311 codec initialiser.
 
     Usage::
 
@@ -96,73 +81,71 @@ class ES8311:
 
     # ------------------------------------------------------------------
     def _init(self):
-        # Reset then release
-        self._wr(_REG_RESET, 0x1F)
+        # --- Reset sequence (matches Espressif es8311_init) ---
+        self._wr(_REG00_RESET, 0x1F)   # assert reset
         time.sleep_ms(20)
-        self._wr(_REG_RESET, 0x00)
+        self._wr(_REG00_RESET, 0x00)   # release reset
+        self._wr(_REG00_RESET, 0x80)   # power-on command (required)
 
-        # Clock configuration — fixed dividers, valid for all sample rates
-        # when MCLK = 256 × sample_rate (see module header).
-        self._wr(_REG_CLK1, _CLK1_MCLK_FROM_PIN)
-        self._wr(_REG_CLK2, 0x00)   # no pre-divider, no frequency doubler
-        self._wr(_REG_CLK3, 0x08)   # SCLKDIV = 8  → BCLK = MCLK / 8
-        self._wr(_REG_CLK4, 0x01)   # LRCKDIV = 0x0100 = 256  (high byte)
-        self._wr(_REG_CLK5, 0x00)   # LRCKDIV low byte
-        self._wr(_REG_CLK6, 0x03)   # ADC oversampling clock divider
-        self._wr(_REG_CLK7, 0x03)   # DAC oversampling clock divider
-        self._wr(_REG_CLK8, 0xFF)   # enable all internal clocks
+        # --- Clock configuration ---
+        # REG01: enable all internal clocks; select MCLK from MCLK pin (bit7=0)
+        self._wr(_REG01_CLK_SRC, 0x3F)
+        # REG02: pre_div=1 (bits[7:5]=000), pre_multi=×1 (bits[4:3]=00)
+        self._wr(_REG02_CLK_DIV, 0x00)
+        # REG03: ADC fs_mode=single-speed (bit6=0), ADC OSR=0x10
+        self._wr(_REG03_ADC_OSR, 0x10)
+        # REG04: DAC OSR=0x10
+        self._wr(_REG04_DAC_OSR, 0x10)
+        # REG05: ADC clk_div=1 (bits[7:4]=0000), DAC clk_div=1 (bits[3:0]=0000)
+        self._wr(_REG05_CLKDIV,  0x00)
+        # REG06: BCLK divider = bclk_div−1 = 4−1 = 3  (MCLK/4 = BCLK for 16-bit stereo)
+        self._wr(_REG06_BCLKDIV, 0x03)
+        # REG07/08: LRCK divider = 0x00FF = 255+1 = 256  (MCLK/256 = sample_rate)
+        self._wr(_REG07_LRCK_H,  0x00)
+        self._wr(_REG08_LRCK_L,  0xFF)
 
-        # I2S serial data format: 16-bit standard I2S, slave mode
-        self._wr(_REG_SDPIN,  _I2S_16BIT_SLAVE)  # ADC (recording)
-        self._wr(_REG_SDPOUT, _I2S_16BIT_SLAVE)  # DAC (playback)
+        # --- I2S serial data format: 16-bit, standard I2S, slave mode ---
+        self._wr(_REG09_SDP_IN,  _SDP_16BIT_SLAVE)  # DAC (playback)
+        self._wr(_REG0A_SDP_OUT, _SDP_16BIT_SLAVE)  # ADC (recording)
 
-        # System / power-up settings (from Espressif ES8311 reference driver)
-        self._wr(_REG_SYSTEM0D, 0x01)
-        self._wr(_REG_SYSTEM0E, 0x02)
-        self._wr(_REG_SYSTEM0F, 0x44)
-        self._wr(_REG_SYSTEM10, 0x1C)  # VSEL: reference voltage for 3.3 V supply
-        self._wr(_REG_SYSTEM11, 0x00)
-        self._wr(_REG_SYSTEM12, 0x02)  # enable MICBIAS for on-board microphone
-        self._wr(_REG_SYSTEM13, 0x10)
-        self._wr(_REG_SYSTEM14, 0x1A)  # power-up ADC; select MIC1 input
+        # --- System / analog power-up ---
+        self._wr(_REG0D_SYS,    0x01)   # power up analog circuitry
+        self._wr(_REG0E_SYS,    0x02)   # enable analog PGA + ADC modulator
+        self._wr(_REG12_DAC_EN, 0x00)   # power up DAC
+        self._wr(_REG13_SYS,    0x10)   # enable output to HP driver
+        self._wr(_REG14_MIC,    0x1A)   # enable analog mic input, max PGA gain
 
-        # ADC (microphone recording)
-        self._wr(_REG_ADC1,    0xBF)  # power on ADC, PGA gain enabled
-        self._wr(_REG_ADC2,    0x00)
-        self._wr(_REG_ADC3,    0x02)  # enable ADC high-pass filter
-        self._wr(_REG_ADC_VOL, 0x00)  # ADC digital volume: 0 dB
-        self._wr(_REG_ADC5,    0x00)
-        self._wr(_REG_ADC6,    0x6C)  # ALC off, noise gate off
+        # --- ADC (microphone) ---
+        self._wr(_REG17_ADC_VOL, 0xC8)  # ADC gain/volume (Espressif default)
+        self._wr(_REG1C_ADC_EQ,  0x6A)  # ADC equalizer bypass, cancel DC offset
 
-        # DAC (speaker playback)
-        self._wr(_REG_DAC1,    0x00)  # power on DAC
-        self._wr(_REG_DAC2,    0xBF)  # enable DAC output and HP driver
-        self._wr(_REG_DAC3,    0x00)
-        self._wr(_REG_DAC4,    0x00)
-        self._wr(_REG_DAC_VOL, 0x00)  # DAC digital volume: 0 dB
-
-        # Analogue power-up
-        self._wr(_REG_ANALOG_PWR, 0x00)
+        # --- DAC (speaker) ---
+        self._wr(_REG32_DAC_VOL, _DEFAULT_VOL_REG)  # set output volume (~85%)
+        self._wr(_REG37_DAC_EQ,  0x08)              # bypass DAC equalizer
 
         print("ES8311: codec initialised")
 
     def set_dac_volume(self, percent):
         """
-        Set DAC (playback) volume.
+        Set DAC (speaker) volume.
 
         Args:
-            percent: 0 (mute) … 100 (0 dB, maximum)
+            percent: 0 (mute) … 100 (maximum)
         """
-        # Linear mapping: 0% → _VOL_REG_MAX_ATTEN (≈ −96 dB), 100% → 0x00 (0 dB)
-        val = int((100 - max(0, min(100, percent))) * _VOL_REG_MAX_ATTEN // 100)
-        self._wr(_REG_DAC_VOL, val)
+        percent = max(0, min(100, percent))
+        if percent == 0:
+            val = 0
+        else:
+            val = (percent * 256 // 100) - 1
+        self._wr(_REG32_DAC_VOL, val)
 
     def set_adc_volume(self, percent):
         """
-        Set ADC (recording) gain.
+        Set ADC (microphone) gain.
 
         Args:
-            percent: 0 (mute) … 100 (0 dB, maximum)
+            percent: 0 (minimum) … 100 (maximum, 0xC8 default)
         """
-        val = int((100 - max(0, min(100, percent))) * _VOL_REG_MAX_ATTEN // 100)
-        self._wr(_REG_ADC_VOL, val)
+        percent = max(0, min(100, percent))
+        val = percent * 0xC8 // 100
+        self._wr(_REG17_ADC_VOL, val)

--- a/internal_filesystem/lib/mpos/audio/audiomanager.py
+++ b/internal_filesystem/lib/mpos/audio/audiomanager.py
@@ -122,7 +122,7 @@ class AudioManager:
 
         @staticmethod
         def _validate_i2s_pins(i2s_pins):
-            allowed = {"sck_in", "sck", "ws", "sd_in"}
+            allowed = {"sck_in", "sck", "ws", "sd_in", "mck"}
             for key in i2s_pins:
                 if key not in allowed:
                     raise ValueError("Invalid i2s_pins key for input: %s" % key)

--- a/internal_filesystem/lib/mpos/audio/audiomanager.py
+++ b/internal_filesystem/lib/mpos/audio/audiomanager.py
@@ -42,6 +42,8 @@ class AudioManager:
             i2s_pins=None,
             buzzer_pin=None,
             preferred_sample_rate=None,
+            on_open=None,
+            on_close=None,
         ):
             if kind not in ("i2s", "buzzer"):
                 raise ValueError("Output.kind must be 'i2s' or 'buzzer'")
@@ -52,6 +54,8 @@ class AudioManager:
             self.kind = kind
             self.channels = channels
             self.preferred_sample_rate = preferred_sample_rate
+            self.on_open = on_open
+            self.on_close = on_close
 
             if kind == "i2s":
                 if not i2s_pins:
@@ -88,6 +92,8 @@ class AudioManager:
             adc_mic_pin=None,
             pdm_pins=None,
             preferred_sample_rate=None,
+            on_open=None,
+            on_close=None,
         ):
             if kind not in ("i2s", "adc", "pdm"):
                 raise ValueError("Input.kind must be 'i2s', 'adc', or 'pdm'")
@@ -98,6 +104,8 @@ class AudioManager:
             self.kind = kind
             self.channels = channels
             self.preferred_sample_rate = preferred_sample_rate
+            self.on_open = on_open
+            self.on_close = on_close
 
             if kind == "i2s":
                 if not i2s_pins:
@@ -726,6 +734,8 @@ class Player:
             i2s_pins=self.output.i2s_pins,
             on_complete=self.on_complete,
             requested_sample_rate=self.sample_rate,
+            on_open=getattr(self.output, "on_open", None),
+            on_close=getattr(self.output, "on_close", None),
         )
         self._stream.play()
 
@@ -810,6 +820,8 @@ class Recorder:
             sample_rate=self.sample_rate,
             i2s_pins=self.input_device.i2s_pins,
             on_complete=self.on_complete,
+            on_open=getattr(self.input_device, "on_open", None),
+            on_close=getattr(self.input_device, "on_close", None),
         )
         self._stream.record()
 

--- a/internal_filesystem/lib/mpos/audio/stream_record_i2s.py
+++ b/internal_filesystem/lib/mpos/audio/stream_record_i2s.py
@@ -27,7 +27,8 @@ class RecordStream:
     DEFAULT_MAX_DURATION_MS = 60000  # 60 seconds max
     DEFAULT_FILESIZE = 1024 * 1024 * 1024 # 1GB data size because it can't be quickly set after recording
 
-    def __init__(self, file_path, duration_ms, sample_rate, i2s_pins, on_complete):
+    def __init__(self, file_path, duration_ms, sample_rate, i2s_pins, on_complete,
+                 on_open=None, on_close=None):
         """
         Initialize recording stream.
 
@@ -37,12 +38,16 @@ class RecordStream:
             sample_rate: Sample rate in Hz
             i2s_pins: Dict with 'sck', 'ws', 'sd_in' pin numbers
             on_complete: Callback function(message) when recording finishes
+            on_open: Optional callable invoked after MCLK starts, before I2S init
+            on_close: Optional callable invoked before I2S deinit
         """
         self.file_path = file_path
         self.duration_ms = duration_ms if duration_ms else self.DEFAULT_MAX_DURATION_MS
         self.sample_rate = sample_rate if sample_rate else self.DEFAULT_SAMPLE_RATE
         self.i2s_pins = i2s_pins
         self.on_complete = on_complete
+        self.on_open = on_open
+        self.on_close = on_close
         self._keep_running = True
         self._is_recording = False
         self._i2s = None
@@ -152,6 +157,13 @@ class RecordStream:
                         except Exception as e:
                             print(f"RecordStream: MCLK PWM init failed: {e}")
 
+                    # Notify codec to prepare for recording (e.g. mute DAC, configure ADC)
+                    if self.on_open:
+                        try:
+                            self.on_open()
+                        except Exception as e:
+                            print(f"RecordStream: on_open failed: {e}")
+
                     # Use sck_in if available (separate clock for mic), otherwise fall back to sck
                     sck_pin = self.i2s_pins.get('sck_in', self.i2s_pins.get('sck'))
                     print(f"RecordStream: Initializing I2S RX with sck={sck_pin}, ws={self.i2s_pins['ws']}, sd={self.i2s_pins['sd_in']}")
@@ -260,6 +272,11 @@ class RecordStream:
 
         finally:
             self._is_recording = False
+            if self.on_close:
+                try:
+                    self.on_close()
+                except Exception as e:
+                    print(f"RecordStream: on_close failed: {e}")
             if self._i2s:
                 self._i2s.deinit()
                 self._i2s = None

--- a/internal_filesystem/lib/mpos/audio/stream_record_i2s.py
+++ b/internal_filesystem/lib/mpos/audio/stream_record_i2s.py
@@ -46,6 +46,7 @@ class RecordStream:
         self._keep_running = True
         self._is_recording = False
         self._i2s = None
+        self._mck_pwm = None
         self._bytes_recorded = 0
         self._start_time_ms = 0
 
@@ -138,6 +139,19 @@ class RecordStream:
             if not use_simulation:
                 # Initialize I2S in RX mode with correct pins for microphone
                 try:
+                    # Start MCLK on mck pin if provided (required for I2S codecs such as ES8311)
+                    if 'mck' in self.i2s_pins:
+                        try:
+                            from machine import Pin, PWM
+                            mck_pin = Pin(self.i2s_pins['mck'], Pin.OUT)
+                            self._mck_pwm = PWM(mck_pin)
+                            mck_freq = self.sample_rate * 256
+                            self._mck_pwm.freq(mck_freq)
+                            self._mck_pwm.duty_u16(32768)  # 50% duty cycle
+                            print(f"RecordStream: MCLK PWM started at {mck_freq} Hz")
+                        except Exception as e:
+                            print(f"RecordStream: MCLK PWM init failed: {e}")
+
                     # Use sck_in if available (separate clock for mic), otherwise fall back to sck
                     sck_pin = self.i2s_pins.get('sck_in', self.i2s_pins.get('sck'))
                     print(f"RecordStream: Initializing I2S RX with sck={sck_pin}, ws={self.i2s_pins['ws']}, sd={self.i2s_pins['sd_in']}")
@@ -249,6 +263,12 @@ class RecordStream:
             if self._i2s:
                 self._i2s.deinit()
                 self._i2s = None
+            if self._mck_pwm:
+                try:
+                    self._mck_pwm.deinit()
+                except Exception:
+                    pass
+                self._mck_pwm = None
             print(f"RecordStream: Recording thread finished")
 
     def get_duration_ms(self):

--- a/internal_filesystem/lib/mpos/audio/stream_wav.py
+++ b/internal_filesystem/lib/mpos/audio/stream_wav.py
@@ -177,6 +177,8 @@ class WAVStream:
         i2s_pins,
         on_complete,
         requested_sample_rate=None,
+        on_open=None,
+        on_close=None,
     ):
         """
         Initialize WAV stream.
@@ -188,6 +190,8 @@ class WAVStream:
             i2s_pins: Dict with 'sck', 'ws', 'sd' pin numbers
             on_complete: Callback function(message) when playback finishes
             requested_sample_rate: Optional negotiated sample rate for shared clocks
+            on_open: Optional callable invoked after MCLK starts, before I2S init
+            on_close: Optional callable invoked before I2S deinit (after audio drains)
         """
         self.file_path = file_path
         self.stream_type = stream_type
@@ -195,6 +199,8 @@ class WAVStream:
         self.i2s_pins = i2s_pins
         self.on_complete = on_complete
         self.requested_sample_rate = requested_sample_rate
+        self.on_open = on_open
+        self.on_close = on_close
         self._keep_running = True
         self._is_playing = False
         self._i2s = None
@@ -449,7 +455,7 @@ class WAVStream:
 
                 self._playback_rate = playback_rate
                 # ibuf = playback_rate # doesnt account for stereo vs mono...
-                ibuf = 32000
+                ibuf = 8192
 
                 print(f"WAVStream: {original_rate} Hz, {bits_per_sample}-bit, {channels}-ch")
                 print(f"WAVStream: Playback at {playback_rate} Hz (factor {upsample_factor})")
@@ -494,6 +500,13 @@ class WAVStream:
                         except Exception as e:
                             print(f"MCLK PWM init failed: {e}")
                             # fallback or error handling
+
+                    # Notify codec/amp to prepare for playback (enable amp, unmute DAC, etc.)
+                    if self.on_open:
+                        try:
+                            self.on_open()
+                        except Exception as e:
+                            print(f"WAVStream: on_open failed: {e}")
 
                     if self.i2s_pins.get("sck"):
                         self._i2s = machine.I2S(
@@ -627,6 +640,11 @@ class WAVStream:
 
         finally:
             self._is_playing = False
+            if self.on_close:
+                try:
+                    self.on_close()
+                except Exception as e:
+                    print(f"WAVStream: on_close failed: {e}")
             if self._i2s:
                 print("Done playing, doing i2s deinit")
                 self._i2s.deinit() # disabling this does not fix the "play just once" issue

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -225,14 +225,33 @@ print("freenove_esp32s3_display.py: init audio (ES8311 + FM8002E)")
 
 # Initialise the ES8311 codec over the shared I2C bus.
 # machine_i2c is already open on SDA=16, SCL=15 from the touch init above.
+_es8311 = None
 try:
     import drivers.codec.es8311 as es8311_drv
-    es8311_drv.ES8311(machine_i2c)
+    _es8311 = es8311_drv.ES8311(machine_i2c)
 except Exception as e:
     print(f"ES8311 init failed: {e}")
 
-# Enable the FM8002E speaker amplifier (GPIO1 LOW = enabled).
-amp_enable = Pin(1, Pin.OUT, value=0)  # LOW = FM8002E amplifier enabled
+# FM8002E speaker amplifier enable pin (GPIO1: LOW=enabled, HIGH=disabled).
+# Start disabled at boot — enabled only around active playback to prevent ring noise.
+_amp_enable = Pin(1, Pin.OUT, value=1)  # HIGH = FM8002E amplifier disabled
+
+
+def _audio_on_open():
+    """Called after MCLK starts and before I2S init. Enables amp and unmutes DAC."""
+    _amp_enable.value(0)          # LOW = enable FM8002E amplifier
+    if _es8311:
+        time.sleep_ms(10)         # let amp rail settle before unmuting
+        _es8311.dac_mute(False)   # release DAC soft-mute
+
+
+def _audio_on_close():
+    """Called before I2S deinit. Mutes DAC then disables amp to suppress pops."""
+    if _es8311:
+        _es8311.dac_mute(True)    # soft-mute DAC first (ramp prevents click)
+        time.sleep_ms(20)         # wait for ramp to complete
+    _amp_enable.value(1)          # HIGH = disable FM8002E amplifier
+
 
 # Register I2S audio devices with AudioManager.
 # Both output and input share MCLK (GPIO4), BCLK (GPIO5), and WS (GPIO7).
@@ -250,6 +269,8 @@ AudioManager.add(
             'ws':  7,   # LRCK
             'sd':  8,   # I2S TX (ESP32 → ES8311 DAC)
         },
+        on_open=_audio_on_open,
+        on_close=_audio_on_close,
     )
 )
 

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -8,7 +8,7 @@ print("freenove_esp32s3_display.py initialization")
 # - Touch: FT6336G capacitive touch, I2C addr 0x38, SDA=16, SCL=15
 # - NeoPixel: WS2812B, 1 LED, GPIO 42
 # - Button: GPIO 0 (INPUT_PULLUP)
-# - Battery ADC: GPIO 9 (voltage divider 2:1 → volts = adcMillivolts × 2.0 / 1000)
+# - Battery ADC: GPIO 9 (200K/200K voltage divider → V_bat = raw_adc × 3.3/4095 × 2)
 # - SD Card: SDMMC 4-bit (CLK=38, CMD=40, D0=39, D1=41, D2=48, D3=47)
 # - Audio: ES8311 codec (I2C SDA=16/SCL=15, I2S MCK=4/BCK=5/DOUT=8/DIN=6/WS=7)
 #          FM8002E amplifier (enable pin GPIO 1, LOW=enabled)
@@ -191,9 +191,10 @@ InputManager.register_indev(btn_indev)
 # ==============================
 print("freenove_esp32s3_display.py: init battery")
 
-def adc_to_voltage(adc_millivolts):
-    # Schematic uses a 2:1 resistor divider; multiply by 2 and convert mV → V
-    return adc_millivolts * 2.0 / 1000.0
+def adc_to_voltage(raw_adc):
+    # Schematic uses equal 200K/200K resistor divider (1:2), so V_bat = V_pin * 2.
+    # raw_adc is a 12-bit value (0-4095) where 4095 = 3.3V at the ADC pin.
+    return raw_adc * (3.3 / 4095) * 2
 
 BatteryManager.init_adc(9, adc_to_voltage)
 

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -81,7 +81,7 @@ mpos.ui.main_display = ili9341.ILI9341(
     color_byte_order=ili9341.BYTE_ORDER_BGR,
     rgb565_byte_swap=True,
     backlight_pin=LCD_BL,
-    backlight_on_state=ili9341.STATE_HIGH,
+    backlight_on_state=ili9341.STATE_PWM,
 )
 
 mpos.ui.main_display.init(2)  # ILI9341_2 (alternative) init sequence, same as M5Stack
@@ -115,7 +115,7 @@ i2c_bus._bus = machine_i2c
 
 touch_dev = i2c.I2C.Device(bus=i2c_bus, dev_id=ft6x36.I2C_ADDR, reg_bits=ft6x36.BITS)
 try:
-    indev = ft6x36.FT6x36(touch_dev, startup_rotation=pointer_framework.lv.DISPLAY_ROTATION._0)
+    indev = ft6x36.FT6x36(touch_dev, startup_rotation=pointer_framework.lv.DISPLAY_ROTATION._270)
     InputManager.register_indev(indev)
 except Exception as e:
     print(f"Touch init got exception: {e}")

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -1,0 +1,213 @@
+print("freenove_esp32s3_display.py initialization")
+# Hardware initialization for Freenove ESP32-S3 Display (FNK0104)
+# Manufacturer's website: https://github.com/Freenove/Freenove_ESP32_S3_Display
+# Hardware Specifications (confirmed from TFT_eSPI_Setups/FNK0104A_2.8_240x320_ILI9341.h
+# and official Freenove sketches, and ES3C28P_ES2N28P_Specification_V1.0.pdf):
+# - MCU: ESP32-S3 (ES3C28P), 16MB Flash, 8MB PSRAM
+# - Display: 2.8" ILI9341V 320x240, SPI (ILI9341_2 variant), BGR, inversion on
+# - Touch: FT6336G capacitive touch, I2C addr 0x38, SDA=16, SCL=15
+# - NeoPixel: WS2812B, 1 LED, GPIO 42
+# - Button: GPIO 0 (INPUT_PULLUP)
+# - Battery ADC: GPIO 9 (voltage divider 2:1 → volts = adcMillivolts × 2.0 / 1000)
+# - SD Card: SDMMC 4-bit (CLK=38, CMD=40, D0=39, D1=41, D2=48, D3=47)
+# - Audio: ES8311 codec (I2C SDA=16/SCL=15, I2S MCK=4/BCK=5/DOUT=8/DIN=6/WS=7)
+#          FM8002E amplifier (enable pin GPIO 1, LOW=enabled)
+# - No IMU
+
+import time
+
+import drivers.display.ili9341 as ili9341
+import i2c
+import lcd_bus
+import lvgl as lv
+import machine
+import mpos.ui
+import pointer_framework
+from machine import Pin
+from micropython import const
+from mpos import BatteryManager, InputManager
+
+# Display SPI pins (confirmed from official FNK0104 TFT_eSPI setup file)
+SPI_BUS  = const(1)
+SPI_FREQ = const(40000000)
+LCD_MOSI = const(11)
+LCD_MISO = const(13)
+LCD_SCLK = const(12)
+LCD_CS   = const(10)
+LCD_DC   = const(46)
+LCD_BL   = const(45)
+# LCD_RST = -1 (tied to 3.3V / board RST, no software reset needed)
+
+# Touch I2C pins (confirmed from official FT6336U sketch)
+TOUCH_SDA = const(16)
+TOUCH_SCL = const(15)
+TOUCH_I2C_FREQ = const(400000)
+
+# Display resolution
+TFT_WIDTH  = const(240)
+TFT_HEIGHT = const(320)
+
+# ==============================
+# Step 1: Display (ILI9341V, SPI)
+# ==============================
+print("freenove_esp32s3_display.py: init SPI display")
+try:
+    spi_bus = machine.SPI.Bus(host=SPI_BUS, mosi=LCD_MOSI, miso=LCD_MISO, sck=LCD_SCLK)
+except Exception as e:
+    print(f"Error initializing SPI bus: {e}")
+    print("Attempting hard reset in 3sec...")
+    time.sleep(3)
+    machine.reset()
+
+display_bus = lcd_bus.SPIBus(
+    spi_bus=spi_bus,
+    freq=SPI_FREQ,
+    dc=LCD_DC,
+    cs=LCD_CS,
+)
+
+_BUFFER_SIZE = const(28800)  # 240 * 60 * 2 bytes (RGB565)
+fb1 = display_bus.allocate_framebuffer(_BUFFER_SIZE, lcd_bus.MEMORY_INTERNAL | lcd_bus.MEMORY_DMA)
+fb2 = display_bus.allocate_framebuffer(_BUFFER_SIZE, lcd_bus.MEMORY_INTERNAL | lcd_bus.MEMORY_DMA)
+
+mpos.ui.main_display = ili9341.ILI9341(
+    data_bus=display_bus,
+    frame_buffer1=fb1,
+    frame_buffer2=fb2,
+    display_width=TFT_WIDTH,
+    display_height=TFT_HEIGHT,
+    color_space=lv.COLOR_FORMAT.RGB565,
+    color_byte_order=ili9341.BYTE_ORDER_BGR,
+    rgb565_byte_swap=True,
+    backlight_pin=LCD_BL,
+    backlight_on_state=ili9341.STATE_HIGH,
+)
+
+mpos.ui.main_display.init(2)  # ILI9341_2 (alternative) init sequence, same as M5Stack
+mpos.ui.main_display.set_power(True)
+mpos.ui.main_display.set_backlight(100)
+mpos.ui.main_display.set_color_inversion(True)  # TFT_INVERSION_ON in official setup
+
+# ==============================
+# Step 2: Touch (FT6336G)
+# ==============================
+print("freenove_esp32s3_display.py: init touch (FT6336G)")
+import drivers.indev.ft6x36 as ft6x36
+
+i2c_bus = i2c.I2C.Bus(host=0, sda=TOUCH_SDA, scl=TOUCH_SCL, freq=TOUCH_I2C_FREQ, use_locks=False)
+touch_dev = i2c.I2C.Device(bus=i2c_bus, dev_id=ft6x36.I2C_ADDR, reg_bits=ft6x36.BITS)
+try:
+    indev = ft6x36.FT6x36(touch_dev, startup_rotation=pointer_framework.lv.DISPLAY_ROTATION._0)
+    InputManager.register_indev(indev)
+except Exception as e:
+    print(f"Touch init got exception: {e}")
+
+mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._270)  # landscape
+
+# ==============================
+# Step 3: Button (GPIO 0)
+# ==============================
+print("freenove_esp32s3_display.py: init button")
+
+btn_boot = Pin(0, Pin.IN, Pin.PULL_UP)
+
+REPEAT_INITIAL_DELAY_MS = 300
+REPEAT_RATE_MS = 100
+last_key = None
+last_state = lv.INDEV_STATE.RELEASED
+key_press_start = 0
+last_repeat_time = 0
+
+# Warning: This gets called several times per second, and if it outputs continuous debugging
+# on the serial line, that will break tools like mpremote from working properly to upload
+# new files over the serial line, thus needing a reflash.
+def keypad_read_cb(indev, data):
+    global last_key, last_state, key_press_start, last_repeat_time
+
+    current_time = time.ticks_ms()
+    current_key = lv.KEY.ESC if btn_boot.value() == 0 else None
+
+    if current_key is None:
+        data.key = last_key if last_key else lv.KEY.ESC
+        data.state = lv.INDEV_STATE.RELEASED
+        last_key = None
+        last_state = lv.INDEV_STATE.RELEASED
+        key_press_start = 0
+        last_repeat_time = 0
+    elif last_key is None or current_key != last_key:
+        data.key = current_key
+        data.state = lv.INDEV_STATE.PRESSED
+        last_key = current_key
+        last_state = lv.INDEV_STATE.PRESSED
+        key_press_start = current_time
+        last_repeat_time = current_time
+    else:
+        elapsed = time.ticks_diff(current_time, key_press_start)
+        since_last_repeat = time.ticks_diff(current_time, last_repeat_time)
+        if elapsed >= REPEAT_INITIAL_DELAY_MS and since_last_repeat >= REPEAT_RATE_MS:
+            data.key = current_key
+            data.state = lv.INDEV_STATE.PRESSED if last_state == lv.INDEV_STATE.RELEASED else lv.INDEV_STATE.RELEASED
+            last_state = data.state
+            last_repeat_time = current_time
+        else:
+            data.state = lv.INDEV_STATE.RELEASED
+            last_state = lv.INDEV_STATE.RELEASED
+
+    if last_state == lv.INDEV_STATE.PRESSED and current_key == lv.KEY.ESC:
+        mpos.ui.back_screen()
+
+group = lv.group_create()
+group.set_default()
+
+btn_indev = lv.indev_create()
+btn_indev.set_type(lv.INDEV_TYPE.KEYPAD)
+btn_indev.set_read_cb(keypad_read_cb)
+btn_indev.set_group(group)
+disp = lv.display_get_default()
+btn_indev.set_display(disp)
+btn_indev.enable(True)
+InputManager.register_indev(btn_indev)
+
+# ==============================
+# Step 4: Battery (GPIO 9, 2:1 voltage divider)
+# ==============================
+print("freenove_esp32s3_display.py: init battery")
+
+def adc_to_voltage(adc_millivolts):
+    # Schematic uses a 2:1 resistor divider; multiply by 2 and convert mV → V
+    return adc_millivolts * 2.0 / 1000.0
+
+BatteryManager.init_adc(9, adc_to_voltage)
+
+# ==============================
+# Step 5: SD Card (SDMMC 4-bit)
+# ==============================
+print("freenove_esp32s3_display.py: init SD card (SDMMC 4-bit)")
+import mpos.sdcard
+mpos.sdcard.init(cmd_pin=40, clk_pin=38, d0_pin=39, d1_pin=41, d2_pin=48, d3_pin=47)
+
+# ==============================
+# Step 6: NeoPixel (WS2812B, 1 LED, GPIO 42)
+# ==============================
+print("freenove_esp32s3_display.py: init NeoPixel")
+import mpos.lights as LightsManager
+LightsManager.init(neopixel_pin=42, num_leds=1)
+
+# ==============================
+# Step 7: Audio (ES8311 codec)
+# TODO: The ES8311 codec requires a non-trivial I2C initialization sequence
+# (PLL config, sample rate, bit depth, I2S format) that has no existing driver
+# in this codebase. Audio support is deferred to a follow-up.
+# For now, keep the FM8002E amplifier disabled (HIGH = off) to save power.
+# I2S pins when audio is implemented (confirmed from Sketch_07.1_Music and schematic):
+#   MCK=4, BCK=5, WS=7
+#   sd=8    (ESP32 TX → codec DAC, playback; schematic labels this "input" from codec's view)
+#   sd_in=6 (ESP32 RX ← codec ADC, recording; schematic labels this "output" from codec's view)
+# I2C (shared with touch): SDA=16, SCL=15, ES8311 addr=0x18
+# ==============================
+print("freenove_esp32s3_display.py: amplifier disabled (audio TODO)")
+amp_enable = Pin(1, Pin.OUT, value=1)  # HIGH = FM8002E amplifier disabled
+
+# IMU: not present on this board — SensorManager not initialized
+
+print("freenove_esp32s3_display.py finished")

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -193,9 +193,9 @@ print("freenove_esp32s3_display.py: init battery")
 
 def adc_to_voltage(raw_adc):
     # Schematic uses equal 200K/200K resistor divider (1:2), so V_bat = V_pin * 2.
-    # The ESP32-S3 ADC with ATTN_11DB has an effective reference of ~3.467V (not 3.3V).
-    # Calibration: raw=2398 → 4.06V measured, so scale = 4.06/2398 ≈ 0.001694 V/count.
-    return raw_adc * (4.06 / 2398)
+    # ATTN_11DB on the ESP32-S3 allows reading up to ~3.5V (used as reference here).
+    # TODO: switch to adc.read_uv() for per-chip factory calibration.
+    return raw_adc * (3.5 / 4095) * 2
 
 BatteryManager.init_adc(9, adc_to_voltage)
 

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -8,7 +8,7 @@ print("freenove_esp32s3_display.py initialization")
 # - Touch: FT6336G capacitive touch, I2C addr 0x38, SDA=16, SCL=15
 # - NeoPixel: WS2812B, 1 LED, GPIO 42
 # - Button: GPIO 0 (INPUT_PULLUP)
-# - Battery ADC: GPIO 9 (200K/200K voltage divider → V_bat = raw_adc × 3.3/4095 × 2)
+# - Battery ADC: GPIO 9 (200K/200K voltage divider → V_bat = raw_adc × 4.06/2398, calibrated at raw=2398 → 4.06V)
 # - SD Card: SDMMC 4-bit (CLK=38, CMD=40, D0=39, D1=41, D2=48, D3=47)
 # - Audio: ES8311 codec (I2C SDA=16/SCL=15, I2S MCK=4/BCK=5/DOUT=8/DIN=6/WS=7)
 #          FM8002E amplifier (enable pin GPIO 1, LOW=enabled)
@@ -193,8 +193,9 @@ print("freenove_esp32s3_display.py: init battery")
 
 def adc_to_voltage(raw_adc):
     # Schematic uses equal 200K/200K resistor divider (1:2), so V_bat = V_pin * 2.
-    # raw_adc is a 12-bit value (0-4095) where 4095 = 3.3V at the ADC pin.
-    return raw_adc * (3.3 / 4095) * 2
+    # The ESP32-S3 ADC with ATTN_11DB has an effective reference of ~3.467V (not 3.3V).
+    # Calibration: raw=2398 → 4.06V measured, so scale = 4.06/2398 ≈ 0.001694 V/count.
+    return raw_adc * (4.06 / 2398)
 
 BatteryManager.init_adc(9, adc_to_voltage)
 

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -218,7 +218,7 @@ LightsManager.init(neopixel_pin=42, num_leds=1)
 #   BCK=5  (BCLK, I2S bit clock)
 #   WS=7   (LRCK, I2S word select)
 #   sd=8   (ESP32 I2S TX → ES8311 SDIN → DAC → speaker)
-#   sd_in=6(ES8311 SDOUT → ADC → ESP32 I2S RX → recording)
+#   sd_in=6 (ES8311 SDOUT → ADC → ESP32 I2S RX → recording)
 # I2C addr 0x18, shared bus with touch (SDA=16, SCL=15)
 # ==============================
 print("freenove_esp32s3_display.py: init audio (ES8311 + FM8002E)")

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -42,6 +42,7 @@ LCD_BL   = const(45)
 TOUCH_SDA = const(16)
 TOUCH_SCL = const(15)
 TOUCH_I2C_FREQ = const(400000)
+TOUCH_RST = const(18)  # FT6336G reset pin (active low)
 
 # Display resolution
 TFT_WIDTH  = const(240)
@@ -94,7 +95,24 @@ mpos.ui.main_display.set_color_inversion(True)  # TFT_INVERSION_ON in official s
 print("freenove_esp32s3_display.py: init touch (FT6336G)")
 import drivers.indev.ft6x36 as ft6x36
 
+# Hardware reset of FT6336G via RST pin (GPIO18, active low).
+# Freenove's official FT6336U library drives RST low for 10ms then waits
+# for the chip to stabilize before any I2C communication.
+touch_rst = Pin(TOUCH_RST, Pin.OUT)
+touch_rst.value(0)
+time.sleep_ms(10)
+touch_rst.value(1)
+time.sleep_ms(200)  # chip needs time to fully initialize after reset
+
+# Use a plain machine.I2C and override _bus in the LVGL I2C.Bus wrapper.
+# This avoids an IDF I2C driver conflict: fail_save_i2c() in board detection
+# leaves machine.I2C(0) open on the same pins, and creating i2c.I2C.Bus(host=0)
+# on top of it can leave subsequent write_readinto calls returning ENODEV.
+# This is the same pattern used by m5stack_core2 (also FT6x36 touch).
+machine_i2c = machine.I2C(0, sda=Pin(TOUCH_SDA), scl=Pin(TOUCH_SCL), freq=TOUCH_I2C_FREQ)
 i2c_bus = i2c.I2C.Bus(host=0, sda=TOUCH_SDA, scl=TOUCH_SCL, freq=TOUCH_I2C_FREQ, use_locks=False)
+i2c_bus._bus = machine_i2c
+
 touch_dev = i2c.I2C.Device(bus=i2c_bus, dev_id=ft6x36.I2C_ADDR, reg_bits=ft6x36.BITS)
 try:
     indev = ft6x36.FT6x36(touch_dev, startup_rotation=pointer_framework.lv.DISPLAY_ROTATION._0)

--- a/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
+++ b/internal_filesystem/lib/mpos/board/freenove_esp32s3_display.py
@@ -115,7 +115,7 @@ i2c_bus._bus = machine_i2c
 
 touch_dev = i2c.I2C.Device(bus=i2c_bus, dev_id=ft6x36.I2C_ADDR, reg_bits=ft6x36.BITS)
 try:
-    indev = ft6x36.FT6x36(touch_dev, startup_rotation=pointer_framework.lv.DISPLAY_ROTATION._270)
+    indev = ft6x36.FT6x36(touch_dev, startup_rotation=pointer_framework.lv.DISPLAY_ROTATION._180)
     InputManager.register_indev(indev)
 except Exception as e:
     print(f"Touch init got exception: {e}")
@@ -212,19 +212,61 @@ import mpos.lights as LightsManager
 LightsManager.init(neopixel_pin=42, num_leds=1)
 
 # ==============================
-# Step 7: Audio (ES8311 codec)
-# TODO: The ES8311 codec requires a non-trivial I2C initialization sequence
-# (PLL config, sample rate, bit depth, I2S format) that has no existing driver
-# in this codebase. Audio support is deferred to a follow-up.
-# For now, keep the FM8002E amplifier disabled (HIGH = off) to save power.
-# I2S pins when audio is implemented (confirmed from Sketch_07.1_Music and schematic):
-#   MCK=4, BCK=5, WS=7
-#   sd=8    (ESP32 TX → codec DAC, playback; schematic labels this "input" from codec's view)
-#   sd_in=6 (ESP32 RX ← codec ADC, recording; schematic labels this "output" from codec's view)
-# I2C (shared with touch): SDA=16, SCL=15, ES8311 addr=0x18
+# Step 7: Audio (ES8311 codec + FM8002E amplifier)
+# I2S pins (confirmed from Freenove Sketch_07.1_Music and schematic):
+#   MCK=4  (MCLK to codec — driven by PWM during playback/recording)
+#   BCK=5  (BCLK, I2S bit clock)
+#   WS=7   (LRCK, I2S word select)
+#   sd=8   (ESP32 I2S TX → ES8311 SDIN → DAC → speaker)
+#   sd_in=6(ES8311 SDOUT → ADC → ESP32 I2S RX → recording)
+# I2C addr 0x18, shared bus with touch (SDA=16, SCL=15)
 # ==============================
-print("freenove_esp32s3_display.py: amplifier disabled (audio TODO)")
-amp_enable = Pin(1, Pin.OUT, value=1)  # HIGH = FM8002E amplifier disabled
+print("freenove_esp32s3_display.py: init audio (ES8311 + FM8002E)")
+
+# Initialise the ES8311 codec over the shared I2C bus.
+# machine_i2c is already open on SDA=16, SCL=15 from the touch init above.
+try:
+    import drivers.codec.es8311 as es8311_drv
+    es8311_drv.ES8311(machine_i2c)
+except Exception as e:
+    print(f"ES8311 init failed: {e}")
+
+# Enable the FM8002E speaker amplifier (GPIO1 LOW = enabled).
+amp_enable = Pin(1, Pin.OUT, value=0)  # LOW = FM8002E amplifier enabled
+
+# Register I2S audio devices with AudioManager.
+# Both output and input share MCLK (GPIO4), BCLK (GPIO5), and WS (GPIO7).
+# Only one I2S session can be active at a time; AudioManager handles conflicts.
+from mpos import AudioManager
+
+AudioManager.add(
+    AudioManager.Output(
+        name="Speaker",
+        kind="i2s",
+        channels=1,
+        i2s_pins={
+            'mck': 4,   # MCLK — PWM-driven at 256 × sample_rate during playback
+            'sck': 5,   # BCLK
+            'ws':  7,   # LRCK
+            'sd':  8,   # I2S TX (ESP32 → ES8311 DAC)
+        },
+    )
+)
+
+AudioManager.add(
+    AudioManager.Input(
+        name="Microphone",
+        kind="i2s",
+        channels=1,
+        i2s_pins={
+            'mck':   4,  # MCLK — PWM-driven at 256 × sample_rate during recording
+            'sck':   5,  # BCLK
+            'ws':    7,  # LRCK
+            'sd_in': 6,  # I2S RX (ES8311 ADC → ESP32)
+        },
+        preferred_sample_rate=16000,
+    )
+)
 
 # IMU: not present on this board — SensorManager not initialized
 

--- a/internal_filesystem/lib/mpos/main.py
+++ b/internal_filesystem/lib/mpos/main.py
@@ -202,6 +202,12 @@ def detect_board():
                     return "waveshare_esp32_s3_touch_lcd_2"
                 restore_i2c(sda=48, scl=47) # fix pin 47 (data6) and 48 (data7) breaking lilygo_t_display_s3's display
                 
+            print("freenove_esp32s3_display ?")
+            if i2c0 := fail_save_i2c(sda=16, scl=15):
+                if single_address_i2c_scan(i2c0, 0x38): # FT6336G touch controller
+                    return "freenove_esp32s3_display"
+                restore_i2c(sda=16, scl=15)
+
             print("fri3d_2024 ?")
             if i2c0 := fail_save_i2c(sda=9, scl=18):
                 if single_address_i2c_scan(i2c0, 0x6A): # ) 0x15: CST8 touch, 0x6A: IMU


### PR DESCRIPTION
(note: code was written by Copilot but it is working on my device and I can fix whatever you'd like personally)

This PR adds support for [Freenove's ESP32-S3 2.8" display with touch board (FNK0104)](https://store.freenove.com/products/fnk0104). Documentation and sample code can be found here: https://github.com/Freenove/Freenove_ESP32_S3_Display/

It seems to actually just be a generic board that Freenove slapped their branding on. You can find what appears to be the same board listed as ES3C28P on Aliexpress. Freenove's github repo has docs for a board named ES3C28P too.

The board was incorrectly identified as `fri3d_2026` before making any changes, which is why the check for this board is before `fri3d`. I don't know why the board was misidentified though.

The speakers were making a high pitched (but quiet) sound constantly so there are changes in here which disables the DAC when no audio is playing. This should reduce power consumption too. It is not implemented for other boards.

I've personally tested:
* Display
* Backlight brightness
* The boot button (maps to back)
* Touchscreen (single touch - is there anything that needs multitouch?)
* Audio playback
* Audio recording
* LED
* Battery level (it's not super accurate but that may be because we need to use `read_uv()` so the result is calibrated)
* SD card

Should fix https://github.com/MicroPythonOS/MicroPythonOS/issues/119 