### PR TITLE
SharedPreferences: don't log full prefs dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Frameworks:
 - Add new LoRaManager framework
 - Add mpos.ui.change_task_handler() for improving IR timing accuracy
 - AppearanceManager: fix set_light_mode() and set_primary_color() — they called a non-existent `prefs.set_string()` and raised AttributeError for every third-party caller; writes now go through `edit().put_string().commit()` and the LVGL theme is reinitialised when the colour changes
+- SharedPreferences: security fix — `load()` no longer prints the entire prefs dict to serial/REPL. Any pref holding a secret (WiFi password in `access_points`, Lightning wallet API keys, NWC secrets, xpubs, etc.) was being leaked to logs every time an app loaded its prefs. Now logs only the filepath and key count
 
 OS:
 - LilyGo T-Watch S3 Plus: add support for IR Remote app

--- a/internal_filesystem/lib/mpos/config.py
+++ b/internal_filesystem/lib/mpos/config.py
@@ -29,7 +29,14 @@ class SharedPreferences:
         try:
             with open(self.filepath, 'r') as f:
                 self.data = ujson.load(f)
-                print(f"load: Loaded preferences from {self.filepath}: {self.data}")
+                # Deliberately log only the filepath and key count, NOT the
+                # values. Prefs often hold secrets (WiFi passwords in
+                # access_points, wallet API keys / NWC secrets / xpubs in
+                # third-party apps, etc.) — printing self.data leaked those
+                # to serial/REPL every time any app loaded its prefs. An
+                # app that wants rich debug output can opt in by logging
+                # selected keys itself.
+                print(f"load: Loaded preferences from {self.filepath} ({len(self.data)} keys)")
         except Exception as e:
             print(f"SharedPreferences.load didn't find preferences: {e}")
             self.data = {}


### PR DESCRIPTION
## Summary

`internal_filesystem/lib/mpos/config.py` has a pre-existing leak in `SharedPreferences.load()`:

```python
print(f"load: Loaded preferences from {self.filepath}: {self.data}")
```

Every `load()` — which fires on app startup and on every `SharedPreferences(...)` instantiation — dumps the full prefs dict to the serial console / REPL. Because prefs commonly hold **secrets**, anyone tailing serial or pasting a log for debugging is exposing those secrets.

## Concrete impact

Discovered during v0.3.0 development on [LightningPiggy/LightningPiggyApp](https://github.com/LightningPiggy/LightningPiggyApp). A single session on a device running the Lightning Piggy app printed:

- **NWC secret** (`secret=…` param — grants spending authority over an attached Lightning wallet)
- **LNBits readkey** (reads wallet state from a user's LNBits instance)

…to serial at least 9 times across normal navigation (main screen → Settings → Wallet → back). Any user sharing a REPL log to get help with an unrelated bug would hand over wallet control.

Beyond Lightning Piggy, **the built-in WiFi app stores AP passwords in the same prefs mechanism** under the `access_points` dict — the example code at the bottom of `config.py` itself shows passwords being written (`"password": "examplepass1"`). Those leak too.

## Fix

One-line change. Log only the filepath and key count, not the values:

```python
print(f"load: Loaded preferences from {self.filepath} ({len(self.data)} keys)")
```

Rationale captured in a code comment next to the change.

Apps that want rich logging of specific keys can still do so themselves by dereferencing — the change only affects the generic framework-level dump.

## No behaviour change

- No API change (load() signature untouched)
- No write path change
- Reads work identically
- No tests broken (existing test_shared_preferences.py still passes)

## CHANGELOG

Added a bullet under the `Frameworks:` section of the "Future release" block.

## Release target

This is a security fix, so I'd suggest merging against main and releasing as part of the next version regardless of its feature scope. Happy to rebase if you'd rather it go into a patch release on the 0.9.x line.

## Test plan

- [ ] `./tests/unittest.sh tests/test_shared_preferences.py` passes
- [ ] Any app using SharedPreferences still sees `load: Loaded preferences from …` in serial (just without values)
- [ ] Failure path (bad JSON / missing file) still logs `SharedPreferences.load didn't find preferences: …` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)