### PR TITLE
Settings → Wi-Fi: redact password from serial/REPL logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Frameworks:
 - AppearanceManager: fix set_light_mode() and set_primary_color() — they called a non-existent `prefs.set_string()` and raised AttributeError for every third-party caller; writes now go through `edit().put_string().commit()` and the LVGL theme is reinitialised when the colour changes
 - SharedPreferences: security fix — `load()` no longer prints the entire prefs dict to serial/REPL. Any pref holding a secret (WiFi password in `access_points`, Lightning wallet API keys, NWC secrets, xpubs, etc.) was being leaked to logs every time an app loaded its prefs. Now logs only the filepath and key count
 
+Builtin Apps:
+- Settings → Wi-Fi: security fix — password no longer printed to serial/REPL during connection attempts, EditNetwork form returns, or Wi-Fi QR scans. Redacts the three print sites that were leaking the password on every Wi-Fi interaction
+
 OS:
 - LilyGo T-Watch S3 Plus: add support for IR Remote app
 - Fri3d 2024: add support for IR remote app

--- a/internal_filesystem/builtin/apps/com.micropythonos.settings.wifi/assets/wifi_settings.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.settings.wifi/assets/wifi_settings.py
@@ -155,7 +155,15 @@ class WiFiSettings(Activity):
         self.startActivityForResult(intent, self.edit_network_result_callback)
 
     def edit_network_result_callback(self, result):
-        print(f"EditNetwork finished, result: {result}")
+        # Redact the password field from the dict dump — `result["data"]`
+        # contains the WiFi password in plaintext and gets printed to
+        # serial/REPL every time the user saves an EditNetwork screen.
+        _redacted = dict(result) if isinstance(result, dict) else result
+        if isinstance(_redacted, dict) and isinstance(_redacted.get("data"), dict):
+            _redacted["data"] = dict(_redacted["data"])
+            if "password" in _redacted["data"]:
+                _redacted["data"]["password"] = "***"
+        print(f"EditNetwork finished, result: {_redacted}")
         if result.get("result_code") is True:
             data = result.get("data")
             if data:
@@ -172,7 +180,9 @@ class WiFiSettings(Activity):
                     self.start_attempt_connecting(ssid, password)
 
     def start_attempt_connecting(self, ssid, password):
-        print(f"start_attempt_connecting: Attempting to connect to SSID '{ssid}' with password '{password}'")
+        # Log only the SSID — the password is sensitive and was being
+        # printed to serial/REPL on every connect attempt.
+        print(f"start_attempt_connecting: Attempting to connect to SSID '{ssid}'")
         self.scan_button.add_state(lv.STATE.DISABLED)
         self.scan_button_label.set_text("Connecting...")
         if self.busy_connecting:
@@ -382,10 +392,14 @@ class EditNetwork(Activity):
             self.startActivityForResult(Intent(activity_class=CameraActivity).putExtra("scanqr_intent", True), self.gotqr_result_callback)
 
     def gotqr_result_callback(self, result):
-        print(f"QR capture finished, result: {result}")
+        # Don't print the raw result — a WiFi QR code's payload
+        # (`WIFI:T:...;S:SSID;P:password;H:...;;`) contains the password
+        # in plaintext and this runs every time a QR is scanned.
+        print("QR capture finished, result_code={}".format(
+            result.get("result_code") if isinstance(result, dict) else None))
         if result.get("result_code"):
             data = result.get("data")
-            print(f"Setting textarea data: {data}")
+            # Not logging `data` either — same reason: it's the raw QR.
             authentication_type, ssid, password, hidden = self.decode_wifi_qr_code(data)
             if ssid and self.ssid_ta: # not always present
                 self.ssid_ta.set_text(ssid)


### PR DESCRIPTION
## Summary

Three `print` sites in `builtin/apps/com.micropythonos.settings.wifi/assets/wifi_settings.py` were dumping the Wi-Fi password to the serial console / REPL on every Wi-Fi interaction:

1. **`edit_network_result_callback` (line 158):**
   ```python
   print(f"EditNetwork finished, result: {result}")
   ```
   `result` is `{'result_code': True, 'data': {'ssid': '…', 'password': '…', 'hidden': …}}` — fires every time the user saves the EditNetwork screen.

2. **`start_attempt_connecting` (line 175):**
   ```python
   print(f"start_attempt_connecting: Attempting to connect to SSID '{ssid}' with password '{password}'")
   ```
   Fires on every connection attempt.

3. **`gotqr_result_callback` (lines 395 and 398):**
   ```python
   print(f"QR capture finished, result: {result}")
   # ...
   print(f"Setting textarea data: {data}")
   ```
   A Wi-Fi QR code's payload is the standard `WIFI:T:WPA;S:SSID;P:password;H:…;;` format — the password is in plaintext. Both `result` and `data` contain it. Fires every time a Wi-Fi QR is scanned.

## Discovery

Spotted while testing the LightningPiggyApp's Wi-Fi reconnect flow. The device printed the user's real home Wi-Fi password to serial on every connection retry. Same class of leak as #123 (SharedPreferences.load) but at the app layer.

## Fix

- `edit_network_result_callback`: shallow-copy the result and replace the nested `data.password` with `***` before printing.
- `start_attempt_connecting`: log only the SSID; drop the password from the print.
- `gotqr_result_callback`: replace the two raw-content prints with a minimal status print (just `result_code`).

All three edits include a comment explaining *why* so future edits don't accidentally regress.

## No behaviour change

- No API change
- No control flow change
- No test impact
- Only log output

## CHANGELOG

Added a bullet under the new `Builtin Apps:` subsection of the "Future release" block.

## Release target

Security fix, suggest merging to main for inclusion in the next release regardless of its feature scope. If you'd rather fold it into a patch release, happy to rebase.

## Test plan

- [ ] Open Settings → Wi-Fi → select an SSID, enter a password, Save. Verify REPL shows `EditNetwork finished, result: {'result_code': True, 'data': {'ssid': '…', 'password': '***', 'hidden': …}}`
- [ ] Same flow triggers connection — verify REPL shows `start_attempt_connecting: Attempting to connect to SSID 'X'` with **no** password
- [ ] Scan a Wi-Fi QR code — verify REPL shows only `QR capture finished, result_code=True` and no raw `WIFI:…;P:password;;` string

🤖 Generated with [Claude Code](https://claude.com/claude-code)