### PR TITLE
make expander analog method a property again

### DIFF
--- a/internal_filesystem/lib/drivers/fri3d/expander.py
+++ b/internal_filesystem/lib/drivers/fri3d/expander.py
@@ -40,6 +40,7 @@ class Expander(Device):
     def int_callback(self, p):
         self.i2c.readfrom_mem_into(self.address, _EXPANDER_REG_INPUTS, self._rx_mv)
 
+    @property
     def analog(self) -> tuple[int, int, int, int, int, int]:
         """Read the analog inputs: ain1, ain0, battery_monitor, usb_monitor, joystick_y, joystick_x"""
         return self._read("<HHHHHH", _EXPANDER_REG_ANALOG, 12)


### PR DESCRIPTION
The annotation was removed in 4b69252265d3b2ff97103d9f1e8674d14008001e