### PR TITLE
add usb-device-midi from microptyhon-lib to the image

### DIFF
--- a/manifests/manifest.py
+++ b/manifests/manifest.py
@@ -1,3 +1,5 @@
 freeze('../internal_filesystem/', 'main.py') # Hardware initialization
 freeze('../internal_filesystem/lib', '') # Additional libraries
 freeze('../freezeFS/', 'freezefs_mount_builtin.py') # Built-in apps
+package("usb", base_path="../lvgl_micropython/lib/micropython/lib/micropython-lib/micropython/usb/usb-device")
+package("usb", base_path="../lvgl_micropython/lib/micropython/lib/micropython-lib/micropython/usb/usb-device-midi")


### PR DESCRIPTION
The goal is to create a MicropythonOS app that acts as a USB MIDI device.