### PR TITLE
DownloadManager: add redact_url= kwarg to hide auth-bearing URLs in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Board Support:
 OS:
 - Disable the repl on hardware uart for esp32s3 targets (USB serial still works)
 
+Frameworks:
+- `DownloadManager.download_url`: add `redact_url=True` kwarg for callers fetching URLs that embed an auth secret (API key, OAuth token, LNBits readkey, xpub/ypub/zpub). When set, the URL is logged as `scheme://host/...REDACTED...`, the response-headers dump is suppressed, and exception messages have any embedded URL scrubbed. Default `False` preserves existing debug output for callers fetching public URLs (app icons, OS updates, etc.). Use case: prevents serial / REPL logs from leaking the secret-bearing URL even when DEBUG-level chatter is on.
+
 0.9.5
 =====
 

--- a/internal_filesystem/lib/mpos/net/download_manager.py
+++ b/internal_filesystem/lib/mpos/net/download_manager.py
@@ -28,12 +28,12 @@ class DownloadManager:
     @classmethod
     def download_url(cls, url, outfile=None, total_size=None,
                     progress_callback=None, chunk_callback=None, headers=None,
-                    speed_callback=None):
+                    speed_callback=None, redact_url=False):
         """Download a URL with flexible output modes (sync or async wrapper).
-        
+
         This method automatically detects whether it's being called from an async context
         and either returns a coroutine (for await) or runs synchronously.
-        
+
         Args:
             url (str): URL to download (required)
             outfile (str, optional): Path to write file. If None, returns bytes.
@@ -42,12 +42,21 @@ class DownloadManager:
             chunk_callback (coroutine, optional): async def callback(chunk: bytes)
             headers (dict, optional): HTTP headers (e.g., {'Range': 'bytes=1000-'})
             speed_callback (coroutine, optional): async def callback(bytes_per_second: float)
-        
+            redact_url (bool, optional): Opt in to redacting the URL in log
+                output and the response-headers dump. Set True whenever the
+                URL embeds an auth secret in its path or query string —
+                e.g. an API key, an OAuth token, an LNBits readkey, or an
+                xpub/ypub/zpub (which exposes the wallet's whole derivation
+                tree). Only the `scheme://host[:port]` prefix is kept in
+                logs; path + query are replaced with "/...REDACTED...".
+                Defaults to False to preserve current debug output for
+                callers fetching public URLs (app icons, OS updates, etc.).
+
         Returns:
             bytes: Downloaded content (if outfile and chunk_callback are None)
             bool: True if successful (when using outfile or chunk_callback)
             coroutine: If called from async context, returns awaitable
-        
+
         Raises:
             ValueError: If both outfile and chunk_callback are provided
         """
@@ -59,20 +68,44 @@ class DownloadManager:
                 # We're in an async context, return the coroutine
                 return cls._download_url_async(url, outfile, total_size,
                                               progress_callback, chunk_callback, headers,
-                                              speed_callback)
+                                              speed_callback, redact_url)
             except RuntimeError:
                 # No running event loop, run synchronously
                 return asyncio.run(cls._download_url_async(url, outfile, total_size,
                                                           progress_callback, chunk_callback, headers,
-                                                          speed_callback))
+                                                          speed_callback, redact_url))
         except ImportError:
             # asyncio not available, shouldn't happen but handle gracefully
             raise ImportError("asyncio module not available")
-    
+
+    @staticmethod
+    def _safe_url(url):
+        """Return a log-safe rendering of `url` for use when the original URL
+        carries a secret in its path or query string. Strips everything
+        after `scheme://host[:port]` and replaces it with "/...REDACTED...".
+
+        Examples:
+            https://example.com/api/v2/xpub/zpub6q...  -> https://example.com/...REDACTED...
+            https://api.example.com:8080/p?key=abc     -> https://api.example.com:8080/...REDACTED...
+            https://example.com                        -> https://example.com  (no path to redact)
+            not-a-url                                  -> ...REDACTED...
+        """
+        try:
+            scheme_end = url.find("://")
+            if scheme_end < 0:
+                return "...REDACTED..."
+            path_start = url.find("/", scheme_end + 3)
+            if path_start < 0:
+                # No path component — nothing sensitive to strip.
+                return url
+            return url[:path_start] + "/...REDACTED..."
+        except Exception:
+            return "...REDACTED..."
+
     @classmethod
     async def _download_url_async(cls, url, outfile=None, total_size=None,
                                  progress_callback=None, chunk_callback=None, headers=None,
-                                 speed_callback=None):
+                                 speed_callback=None, redact_url=False):
         """Download a URL with flexible output modes.
         
         Args:
@@ -83,11 +116,14 @@ class DownloadManager:
             chunk_callback (coroutine, optional): async def callback(chunk: bytes)
             headers (dict, optional): HTTP headers (e.g., {'Range': 'bytes=1000-'})
             speed_callback (coroutine, optional): async def callback(bytes_per_second: float)
-        
+            redact_url (bool, optional): When True, log a redacted URL
+                (scheme://host only) and suppress the response-headers dump.
+                See `download_url` for details and use cases.
+
         Returns:
             bytes: Downloaded content (if outfile and chunk_callback are None)
             bool: True if successful (when using outfile or chunk_callback)
-        
+
         Raises:
             ValueError: If both outfile and chunk_callback are provided
         """
@@ -98,6 +134,11 @@ class DownloadManager:
                 "Use outfile for saving to disk, or chunk_callback for streaming."
             )
 
+        # Compute the log-safe rendering once; used for every URL-bearing print
+        # below. When redact_url is False this is just the original URL, so
+        # existing behaviour is preserved verbatim.
+        log_url = cls._safe_url(url) if redact_url else url
+
         import aiohttp
         session = aiohttp.ClientSession()
         sslctx = None # for http
@@ -106,7 +147,7 @@ class DownloadManager:
             sslctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             sslctx.verify_mode = ssl.CERT_OPTIONAL # CERT_REQUIRED might fail because MBEDTLS_ERR_SSL_CA_CHAIN_REQUIRED
 
-        print(f"DownloadManager: Downloading {url}")
+        print(f"DownloadManager: Downloading {log_url}")
         
         fd = None
         try:
@@ -120,7 +161,13 @@ class DownloadManager:
                     raise RuntimeError(f"HTTP {response.status}")
                 
                 # Figure out total size and starting offset (for resume support)
-                print("DownloadManager: Response headers:", response.headers)
+                # When redacting, suppress the headers dump entirely — response
+                # headers can include `set-cookie`, `cf-ray` and other tokens
+                # that correlate to the request's secret-bearing URL.
+                if redact_url:
+                    print("DownloadManager: Response headers: <redacted>")
+                else:
+                    print("DownloadManager: Response headers:", response.headers)
                 resume_offset = 0  # Starting byte offset (0 for new downloads, >0 for resumed)
                 
                 if total_size is None:
@@ -241,7 +288,7 @@ class DownloadManager:
                                 speed_last_update_time = current_time
                     else:
                         # Chunk is None, download complete
-                        print(f"DownloadManager: Finished downloading {url}")
+                        print(f"DownloadManager: Finished downloading {log_url}")
                         if fd:
                             fd.close()
                             fd = None
@@ -252,7 +299,12 @@ class DownloadManager:
                             return b''.join(chunks)
         
         except Exception as e:
-            print(f"DownloadManager: Exception during download: {e}")
+            # Exception strings from aiohttp often embed the full URL —
+            # scrub it before printing when the caller asked for redaction.
+            err_str = str(e)
+            if redact_url and url in err_str:
+                err_str = err_str.replace(url, log_url)
+            print(f"DownloadManager: Exception during download: {err_str}")
             if fd:
                 fd.close()
             raise  # Re-raise the exception instead of suppressing it

--- a/internal_filesystem/lib/mpos/testing/mocks.py
+++ b/internal_filesystem/lib/mpos/testing/mocks.py
@@ -747,11 +747,12 @@ class MockDownloadManager:
     
     async def download_url(self, url, outfile=None, total_size=None,
                           progress_callback=None, chunk_callback=None, headers=None,
-                          speed_callback=None):
+                          speed_callback=None, redact_url=False):
         """Mock async download with flexible output modes."""
         self.url_received = url
         self.headers_received = headers
-        
+        self.redact_url_received = redact_url
+
         self.call_history.append({
             'url': url,
             'outfile': outfile,
@@ -759,7 +760,8 @@ class MockDownloadManager:
             'headers': headers,
             'has_progress_callback': progress_callback is not None,
             'has_chunk_callback': chunk_callback is not None,
-            'has_speed_callback': speed_callback is not None
+            'has_speed_callback': speed_callback is not None,
+            'redact_url': redact_url,
         })
         
         if self.should_fail:

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -617,3 +617,150 @@ class TestRedactUrlKwarg(unittest.TestCase):
 
         self.assertEqual(mock.call_history[-1]['redact_url'], True)
         self.assertEqual(mock.redact_url_received, True)
+
+
+class TestRedactedExceptionPath(unittest.TestCase):
+    """End-to-end verification of the URL-bearing exception scrubbing in
+    `_download_url_async`'s `except` handler.
+
+    Real-world trigger: aiohttp's `ClientConnectorError` (and friends) often
+    embed the full request URL in `str(e)`. Without scrubbing, the
+    `print(f"DownloadManager: Exception during download: {err_str}")` line
+    leaks the secret-bearing URL to the serial / REPL log on every failed
+    download attempt — exactly the case `redact_url=True` is meant to cover.
+
+    Strategy: install a fake `aiohttp` module into `sys.modules` so the
+    function-local `import aiohttp` inside `_download_url_async` resolves to
+    our fake. The fake's `ClientSession.get(...)` raises a `RuntimeError`
+    whose message contains the full URL — mimicking aiohttp's behaviour
+    closely enough to exercise the `if redact_url and url in err_str`
+    branch deterministically (no network required).
+    """
+
+    def _capture_download_with_failing_aiohttp(self, *, url, redact_url,
+                                                exc_message):
+        """Run `_download_url_async(url, redact_url=...)` against a fake
+        aiohttp that raises `RuntimeError(exc_message)` from `session.get()`.
+        Returns (captured_print_lines, raised_exception_or_None).
+        """
+        import asyncio
+        import sys
+        import builtins
+
+        # Minimal fake aiohttp surface — only what _download_url_async touches
+        # before it hits the failure point.
+        class _FakeClientSession:
+            def get(self, request_url, **kwargs):
+                # Raise synchronously from .get() — the `async with
+                # session.get(...) as response:` line will surface this as
+                # an exception inside the outer try/except.
+                raise RuntimeError(exc_message)
+
+            async def close(self):
+                pass
+
+        # MicroPython doesn't support `type(sys)(...)` to instantiate a
+        # fresh module object. The import machinery only checks
+        # `sys.modules` for the name and binds whatever object it finds —
+        # so a plain instance with the right attributes works just as
+        # well for `import aiohttp; aiohttp.ClientSession()`.
+        class _FakeAiohttp:
+            pass
+
+        fake_aiohttp = _FakeAiohttp()
+        fake_aiohttp.ClientSession = _FakeClientSession
+
+        # Capture print output without disturbing other tests' stdout.
+        captured = []
+        orig_print = builtins.print
+
+        def _fake_print(*args, **kwargs):
+            captured.append(" ".join(str(a) for a in args))
+
+        old_aiohttp = sys.modules.get("aiohttp")
+        sys.modules["aiohttp"] = fake_aiohttp
+        builtins.print = _fake_print
+        try:
+            async def _go():
+                await DownloadManager._download_url_async(
+                    url, redact_url=redact_url)
+
+            raised = None
+            try:
+                asyncio.run(_go())
+            except Exception as e:
+                raised = e
+        finally:
+            builtins.print = orig_print
+            if old_aiohttp is None:
+                # Don't leave a fake module behind that would mask real
+                # aiohttp imports in subsequent tests in the same run.
+                try:
+                    del sys.modules["aiohttp"]
+                except KeyError:
+                    pass
+            else:
+                sys.modules["aiohttp"] = old_aiohttp
+
+        return captured, raised
+
+    def test_redact_url_true_scrubs_url_from_exception_print_line(self):
+        # The motivating case: the URL embeds a secret (zpub / API key) in
+        # the path, the aiohttp error embeds that URL in its message, and
+        # the framework's except-handler print would leak it.
+        url = ("https://btc1.trezor.io/api/v2/xpub/"
+               "zpub6qSECRETxpubABCDEFG?details=txs&tokens=derived")
+        exc_message = "Cannot connect to host: {} — DNS failure".format(url)
+
+        captured, raised = self._capture_download_with_failing_aiohttp(
+            url=url, redact_url=True, exc_message=exc_message)
+
+        # The function must still re-raise (the framework's contract is
+        # that scrubbing only affects logs, not control flow).
+        self.assertIsNotNone(raised, "exception should still propagate")
+
+        # Find the exception-print line specifically.
+        exc_lines = [l for l in captured
+                     if "Exception during download:" in l]
+        self.assertTrue(exc_lines,
+                        "expected an 'Exception during download:' "
+                        "print line; got: {}".format(captured))
+
+        for line in exc_lines:
+            # The secret-bearing path component must NOT appear in the
+            # printed exception line.
+            self.assertFalse(
+                "zpub6qSECRETxpubABCDEFG" in line,
+                "secret-bearing URL substring leaked into exception "
+                "print: {}".format(line))
+            self.assertFalse(
+                url in line,
+                "full URL leaked into exception print: {}".format(line))
+            # The redacted form must appear (scheme + host preserved,
+            # path replaced with /...REDACTED...).
+            self.assertIn("https://btc1.trezor.io/...REDACTED...", line)
+
+    def test_redact_url_false_preserves_url_in_exception_print_line(self):
+        # Regression guard: default behaviour MUST keep the full URL in
+        # the exception print line so debugging public-URL downloads
+        # (app icons, OS updates, weather) isn't degraded.
+        url = "https://example.com/path/with/some/components"
+        exc_message = "Cannot connect to host: {}".format(url)
+
+        captured, raised = self._capture_download_with_failing_aiohttp(
+            url=url, redact_url=False, exc_message=exc_message)
+
+        self.assertIsNotNone(raised)
+
+        exc_lines = [l for l in captured
+                     if "Exception during download:" in l]
+        self.assertTrue(exc_lines)
+        self.assertTrue(
+            any(url in l for l in exc_lines),
+            "default behaviour should not scrub URL; "
+            "got lines: {}".format(exc_lines))
+        # And it must NOT redact when not asked to.
+        self.assertFalse(
+            any("...REDACTED..." in l for l in exc_lines),
+            "default behaviour should not insert REDACTED placeholder; "
+            "got lines: {}".format(exc_lines))

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -547,3 +547,73 @@ class TestDownloadManager(unittest.TestCase):
         # Verify progress values are in valid range
         for pct in progress_calls:
             self.assertTrue(0 <= pct <= 100)
+
+
+class TestSafeUrl(unittest.TestCase):
+    """Unit tests for the `_safe_url` helper used by `redact_url=True`."""
+
+    def test_https_with_path_and_query(self):
+        u = "https://btc1.trezor.io/api/v2/xpub/zpub6q...secret...stuff?details=txs&tokens=derived"
+        self.assertEqual(DownloadManager._safe_url(u), "https://btc1.trezor.io/...REDACTED...")
+
+    def test_http_with_port_and_path(self):
+        u = "http://api.example.com:8080/path/secret?key=abc"
+        self.assertEqual(DownloadManager._safe_url(u), "http://api.example.com:8080/...REDACTED...")
+
+    def test_naked_host_no_path_returned_unchanged(self):
+        # Nothing sensitive after the host — nothing to strip.
+        u = "https://example.com"
+        self.assertEqual(DownloadManager._safe_url(u), "https://example.com")
+
+    def test_trailing_slash_only(self):
+        # `https://example.com/` has an empty path; safe to redact as the
+        # function still finds a `/` after the scheme.
+        u = "https://example.com/"
+        self.assertEqual(DownloadManager._safe_url(u), "https://example.com/...REDACTED...")
+
+    def test_malformed_url_returns_generic_placeholder(self):
+        # Anything without `://` is treated as untrusted — replace whole.
+        self.assertEqual(DownloadManager._safe_url("not-a-url-at-all"), "...REDACTED...")
+
+    def test_secret_substrings_never_appear_in_redacted_output(self):
+        # Belt-and-braces check: the secret-bearing parts of the input
+        # must not appear in the redacted output. Catches future regressions
+        # where the redaction logic might accidentally keep a substring.
+        u = "https://idx.example.com/wallet/SECRETxpubABCDEFG?key=TOKEN_VALUE"
+        safe = DownloadManager._safe_url(u)
+        # MicroPython's unittest port has assertIn but not assertNotIn — use
+        # assertFalse(... in ...) for the negative case.
+        self.assertFalse("SECRETxpub" in safe)
+        self.assertFalse("TOKEN_VALUE" in safe)
+        self.assertIn("https://idx.example.com", safe)  # host kept on purpose
+
+
+class TestRedactUrlKwarg(unittest.TestCase):
+    """Verify the redact_url kwarg flows through the call surface (sync wrapper
+    + async impl + mock) without changing default behaviour."""
+
+    def test_mock_records_redact_url_default_false(self):
+        import asyncio
+        mock = MockDownloadManager()
+        # Configure a stub payload so download_url returns deterministic data
+        mock.download_data = b"x"
+
+        async def go():
+            await mock.download_url("https://example.com/path")
+        asyncio.run(go())
+
+        # Default: redact_url not requested.
+        self.assertEqual(mock.call_history[-1]['redact_url'], False)
+        self.assertEqual(mock.redact_url_received, False)
+
+    def test_mock_records_redact_url_true_when_passed(self):
+        import asyncio
+        mock = MockDownloadManager()
+        mock.download_data = b"x"
+
+        async def go():
+            await mock.download_url("https://example.com/path", redact_url=True)
+        asyncio.run(go())
+
+        self.assertEqual(mock.call_history[-1]['redact_url'], True)
+        self.assertEqual(mock.redact_url_received, True)


### PR DESCRIPTION
## Summary

`DownloadManager.download_url` prints the full request URL three times per download (start, finished, exception path) plus the entire response-headers dict. Great for the typical callers fetching public URLs (app icons, OS updates, weather), but it silently leaks any auth secret embedded in the URL's path or query string.

Two real cases motivating this PR:

1. **Lightning Piggy's on-chain wallet** ([LightningPiggyApp PR #25](https://github.com/LightningPiggy/LightningPiggyApp/pull/25)) queries
   `https://btc1.trezor.io/api/v2/xpub/zpub6q…?details=txs&tokens=derived` to fetch balance + transactions for a watch-only xpub. The xpub itself sits in the URL path. A leaked xpub exposes the wallet's entire past + future address derivation tree to whoever reads the log — non-recoverable confidentiality damage even though funds custody is unaffected. The app already scrubs xpubs from its own `print()` calls, but `DownloadManager`'s prints sit below that and re-leak on every poll.

2. **Any future caller using API-key-in-URL or token-in-URL auth.** Common pattern (LNBits, BlueWallet's LNDHub, some HTTPS RPC endpoints) — the leak surface is wider than just Lightning Piggy.

## Behaviour

Adds a `redact_url=False` kwarg (default preserves current behaviour). When `True`:

- URL logged as `scheme://host[:port]/...REDACTED...` instead of full. **The host is intentionally kept** so failure triage (DNS / connectivity / wrong endpoint) is still possible.
- Response-headers dump is suppressed entirely (replaced with `<redacted>`). Response headers often carry `set-cookie`, `cf-ray`, and other correlatable session tokens.
- Exception messages have the URL substring scrubbed before printing (aiohttp's `ClientConnectorError` typically embeds the URL).

Default `False` is deliberate — most callers fetch public URLs and want the full log line for diagnostics. Callers explicitly opt in:

```python
await DownloadManager.download_url(url, redact_url=True)
```

## Tests

`tests/test_download_manager.py` — added 3 new test classes (10 tests):

- `TestSafeUrl` (6 tests) for the new `_safe_url` helper — path-with-query strip, port handling, naked-host pass-through, malformed-URL placeholder, belt-and-braces "secret substrings never appear in output" guard.
- `TestRedactUrlKwarg` (2 tests) confirming the kwarg flows through the call surface (sync wrapper + async impl + mock) and defaults to `False`.
- `TestRedactedExceptionPath` (2 tests, commit `64963f9`) — end-to-end coverage of the URL-bearing exception scrubbing path. Installs a fake `aiohttp` into `sys.modules` so the function-local `import aiohttp` resolves to a stub whose `ClientSession.get()` raises `RuntimeError(message)` with the full URL in the message (mimics aiohttp's `ClientConnectorError` without needing the network), then captures `print(...)` and asserts the secret-bearing substring is scrubbed under `redact_url=True` and preserved under `redact_url=False`.

All 22 existing tests continue to pass (default behaviour unchanged):

```
$ bash tests/unittest.sh tests/test_download_manager.py
Ran 32 tests
OK
```

## Follow-up

Lightning Piggy's on-chain wallet ([PR #25](https://github.com/LightningPiggy/LightningPiggyApp/pull/25)) will follow up on its side to pass `redact_url=True` once this lands. That's a one-line change in `onchain_wallet.py:fetch_balance_and_payments()`.

## Test plan

- [x] All 32 tests pass on macOS desktop (`bash tests/unittest.sh tests/test_download_manager.py`)
- [x] Existing tests (default behaviour) unchanged
- [x] **URL-bearing exception path covered by unit tests** (commit `64963f9`): fake-aiohttp injection deterministically exercises the `except Exception as e: ... url in err_str` branch and verifies both the scrubbed (`redact_url=True`) and preserved (`redact_url=False`) print output
- [ ] **Hardware end-to-end smoke test:** an LP onchain wallet call with `redact_url=True` shows `https://btc1.trezor.io/...REDACTED...` in serial logs. Gated on [LightningPiggy #25](https://github.com/LightningPiggy/LightningPiggyApp/pull/25) follow-up adding the kwarg — will tick once that lands and the integrated build is exercised on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)