### PR TITLE
Fast composed-font emoji rendering via lv_imgfont_set_range

### DIFF
--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -280,9 +280,55 @@ birthday_cakes,👑
         cls._ensure_emoji_maps()
 
         try:
-            return lv.imgfont_create(size, cls._imgfont_path_cb, None)
+            font = lv.imgfont_create(size, cls._imgfont_path_cb, None)
         except Exception:
             return None
+        if font is None:
+            return None
+
+        # Push the same codepoint accept/exclude ranges that _get_emoji_src
+        # checks down into the C-level imgfont. Once set, LVGL stops calling
+        # our Python _imgfont_path_cb for codepoints that are guaranteed to
+        # have no emoji glyph (ASCII, CJK, PUA, etc.) — turning the per-glyph
+        # cost from "Python call + return" into a pair of int compares in C.
+        # This is the actual fix for the scrolling slowdown: composed-font
+        # text where most glyphs are non-emoji now stays in C end-to-end.
+        try:
+            cp_min, cp_max = cls._emoji_codepoint_bounds()
+            lv.imgfont_set_range(font, cp_min, cp_max, 0xE000, 0xF8FF)
+        except AttributeError:
+            # Older LVGL build without lv_imgfont_set_range — that's OK, the
+            # fast path is just a nice-to-have. Behaviour falls back to the
+            # pre-patch composed-font path (correct, just slower).
+            cls._debug("imgfont_set_range unavailable — emoji filter not applied")
+        except Exception as err:
+            cls._debug("imgfont_set_range failed: " + repr(err))
+
+        return font
+
+    @classmethod
+    def _emoji_codepoint_bounds(cls):
+        """Smallest / largest codepoint present across all loaded emoji maps.
+        Recomputed on demand and cached — the maps are immutable after init.
+        Falls back to a safe wide range if no emojis are loaded yet, so we
+        never narrow the filter in a way that would hide future glyphs."""
+        bounds = cls.__dict__.get("_emoji_cp_bounds")
+        if bounds is not None:
+            return bounds
+        lo = None
+        hi = None
+        for emap in cls._emoji_maps.values():
+            for cp in emap:
+                if lo is None or cp < lo: lo = cp
+                if hi is None or cp > hi: hi = cp
+        if lo is None:
+            # No emojis loaded — accept everything so behaviour matches the
+            # unpatched code path. Caller should re-create the font once
+            # maps are populated.
+            return (0, 0xFFFFFFFF)
+        bounds = (lo, hi)
+        cls._emoji_cp_bounds = bounds
+        return bounds
 
     @classmethod
     def _ensure_emoji_maps(cls):

--- a/scripts/build_mpos.sh
+++ b/scripts/build_mpos.sh
@@ -106,6 +106,20 @@ pushd "$codebasedir"/lvgl_micropython/lib/micropython
 patch -p1 --forward < ../../esp32_uart_repl_runtime.patch || true
 popd
 
+# Fast emoji rendering: bake a codepoint range filter into lv_imgfont so
+# non-emoji glyphs bail out in C without invoking the MicroPython path_cb.
+# Pre-existence check so MPOS still builds against older pinned
+# lvgl_micropython SHAs that don't ship this patch yet (FontManager.py
+# degrades gracefully via try/except AttributeError when the setter is
+# absent — see internal_filesystem/lib/mpos/ui/font_manager.py).
+imgfont_patch="$codebasedir"/lvgl_micropython/imgfont_set_range.patch
+if [ -f "$imgfont_patch" ]; then
+	echo "Applying lvgl_micropython imgfont_set_range patch..."
+	pushd "$codebasedir"/lvgl_micropython/lib/lvgl
+	patch -p1 --forward < "$imgfont_patch" || true
+	popd
+fi
+
 echo "Minifying and inlining HTML..."
 pushd "$codebasedir"/webrepl/
 python3 inline_minify_webrepl.py


### PR DESCRIPTION
## Summary

Cuts the per-glyph cost of `FontManager.getFont(emoji=True)` labels from a C→Python round-trip per glyph to two int compares in C, for any codepoint that isn't in the emoji map. User-visible result: noticeably smoother scrolling of any label that uses an emoji-fallback font (Lightning Piggy transactions row, Files list, etc.) — even though most rows have no emoji in them.

## How

Three pieces:

* **`internal_filesystem/lib/mpos/ui/font_manager.py`** — `_create_emoji_font(size)` now calls `lv.imgfont_set_range(font, cp_min, cp_max, 0xE000, 0xF8FF)` after `lv.imgfont_create`. `cp_min`/`cp_max` are computed dynamically from the loaded `_emoji_maps` keys, so the filter self-maintains as the emoji set grows — no hardcoded magic number. Guarded by `try/except AttributeError` so older `lvgl_micropython` pins still work (just without the speedup).
* **`scripts/build_mpos.sh`** — applies `lvgl_micropython/imgfont_set_range.patch` against `lib/lvgl` during the build. Gated by a `-f` existence check, so older `lvgl_micropython` pins (no patch file present) still build cleanly.
* **`lvgl_micropython` submodule** — bumped `916ec6b` → `e00d9d9`. Picks up the new `imgfont_set_range.patch` plus a small drive-by brew-config parser fix in `builder/macOS.py` that was breaking macOS builds entirely.

## Dependency

This PR depends on MicroPythonOS/lvgl_micropython#3. The submodule pointer here references `e00d9d9`, which currently lives only on the `bitcoin3us/lvgl_micropython` fork. Once #3 merges into `MicroPythonOS/lvgl_micropython`, this PR's submodule pointer will resolve from upstream and this can land. `.gitmodules` is intentionally untouched (still points at the canonical URL).

## Test plan

- [x] macOS desktop build (`build_mpos.sh macOS`) — clean, `lv.imgfont_set_range` exposed in the LVGL binding
- [x] ESP32-S3 firmware build (`build_mpos.sh esp32s3`) — clean build, patch applies, all expected freezing happens
- [x] Flash + boot on Waveshare ESP32-S3-Touch-LCD-2 — boots cleanly, `lv.imgfont_set_range` callable, FontManager wiring works
- [x] FontManager bounds calculation on device — with the 400-emoji set loaded, bounds resolve to `(0x203C, 0x1F9E2)` (exact min/max across the loaded codepoints, as designed)
- [x] Backward-compat fallback — `try/except AttributeError` path verified mentally (covered by gating in build_mpos.sh)
- [x] User test — scrolling the Lightning Piggy transactions list feels noticeably smoother than the pre-patch firmware