### PR TITLE
SettingActivity: add 'note' field for inline informational text

### DIFF
--- a/internal_filesystem/lib/mpos/ui/setting_activity.py
+++ b/internal_filesystem/lib/mpos/ui/setting_activity.py
@@ -122,6 +122,21 @@ class SettingActivity(Activity):
             self.keyboard.add_flag(lv.obj.FLAG.HIDDEN)
             self.keyboard.set_textarea(self.textarea)
 
+        # Optional informational note below the input widget. Apps use
+        # this for short context that isn't a placeholder/title — e.g.
+        # privacy nudges, hardware caveats, or "why would I pick this".
+        # Wraps to the screen width and uses muted small-font styling
+        # so it never competes with the title above or the value below.
+        note_text = setting.get("note")
+        if note_text:
+            note_label = lv.label(settings_screen_detail)
+            note_label.set_text(note_text)
+            note_label.set_long_mode(lv.label.LONG_MODE.WRAP)
+            note_label.set_width(lv.pct(95))
+            note_label.set_style_text_font(lv.font_montserrat_12, lv.PART.MAIN)
+            note_label.set_style_text_color(lv.color_hex(0x999999), lv.PART.MAIN)
+            note_label.set_style_pad_top(DisplayMetrics.pct_of_width(3), lv.PART.MAIN)
+
         # Button container
         btn_cont = lv.obj(settings_screen_detail)
         btn_cont.set_width(lv.pct(100))


### PR DESCRIPTION
## Summary

Adds an optional \`note\` field to settings dicts. When present, \`SettingActivity\` renders it as a wrapping, muted-grey, 12 pt label between the input widget and the Cancel / Save row.

\`\`\`python
self.settings = [
    {\"title\": \"Wallet Type\", \"ui\": \"radiobuttons\",
     \"ui_options\": [(\"On-chain (xpub or Bitcoin address)\", \"onchain\")],
     \"note\": \"Tip: an xpub is more private than reusing a single address. \"
             \"With an xpub, the wallet derives a fresh receive address per \"
             \"payment so the people paying you can't see your full balance \"
             \"or each other's amounts; with a single address, every payment \"
             \"shares the same on-chain record.\"},
    ...
]
\`\`\`

Optional — settings without a \`note\` field render exactly as before.

## Use case

Lightning Piggy's on-chain wallet (in 0.5.0) is gaining a single-address mode as an alternative to xpub: see LightningPiggy/LightningPiggyApp#45. Picking the single-address shape works but trades away on-chain privacy. Surfacing that trade-off on the same page as the choice helps users make an informed call without burying it in docs.

Generalising to a first-class \`note\` field rather than baking the wording into LP keeps the convention reusable — any setting elsewhere with a similar \"why would I pick this\" gotcha can opt in by adding a single dict key.

## Implementation

Fifteen lines in \`internal_filesystem/lib/mpos/ui/setting_activity.py\`, right after the input-widget branches and before the Cancel/Save button container:

* Plain \`lv.label\` parented on the existing \`settings_screen_detail\`.
* \`LONG_MODE.WRAP\` so multi-line notes flow naturally to the screen width.
* \`set_width(lv.pct(95))\` to match the textarea / radio container width and stay clear of the scroll bar.
* \`font_montserrat_12\` + grey \`0x999999\` so it reads as supporting text without competing with the title above or the value below.
* \`DisplayMetrics.pct_of_width(3)\` top padding so it sits a comfortable distance below the input.

## Compatibility

* **Apps**: pure additive change. Existing settings dicts behave identically.
* **Themes**: uses \`lv.color_hex(0x999999)\` directly rather than a theme-aware token, matching the style of the existing slider value label (\`font_montserrat_24\`) and Cancel button opacity (\`OPA._70\`). If the project gains a theme-aware muted-text token in the future, this label is a one-line swap.

## Test plan

- [x] Setting WITH \`note\` field renders the wrapped grey label below the input on the desktop build
- [x] Setting WITHOUT \`note\` field is byte-identical to pre-PR layout
- [x] Long notes wrap across multiple lines without overlapping the Cancel/Save buttons (the buttons sit in their own flex container below)
- [ ] On-device verification pending a firmware build (will follow up in this PR once tested on Waveshare ESP32-S3-Touch-LCD-2)