### PR TITLE
gesture-nav back button: use lv.SYMBOL.NEW_LINE for the go-back affordance

### DIFF
--- a/internal_filesystem/lib/mpos/ui/gesture_navigation.py
+++ b/internal_filesystem/lib/mpos/ui/gesture_navigation.py
@@ -133,7 +133,15 @@ def handle_back_swipe():
     backbutton.add_flag(lv.obj.FLAG.HIDDEN)
     backbutton.add_state(lv.STATE.DISABLED)
     backlabel = lv.label(backbutton)
-    backlabel.set_text(lv.SYMBOL.LEFT)
+    # lv.SYMBOL.NEW_LINE (FontAwesome U+F149, "↵") instead of
+    # lv.SYMBOL.LEFT (chevron-left "‹"). Same FontAwesome font range,
+    # which MPOS already relies on via `keyboard.py`'s Enter key, so
+    # availability is guaranteed — but the return-arrow shape maps to
+    # the universal "back" / "go back" / "return" affordance from
+    # physical-keyboard convention more directly than the chevron does.
+    # Renders as a hooked left-pointing arrow at the existing 18 pt
+    # weight that matches the surrounding chrome.
+    backlabel.set_text(lv.SYMBOL.NEW_LINE)
     backlabel.set_style_text_font(lv.font_montserrat_18, lv.PART.MAIN)
     backlabel.center()
 


### PR DESCRIPTION
## Summary

The swipe-from-left-edge back button label in `mpos.ui.gesture_navigation.handle_back_swipe()` used `lv.SYMBOL.LEFT` (FontAwesome chevron-left, U+F053). The chevron is conventional but quiet — it reads as a direction more than as an action.

Switching to `lv.SYMBOL.NEW_LINE` (FontAwesome U+F149, "↵"). The return-arrow shape maps to the universal "go back" / "return" affordance from physical-keyboard convention more directly than the chevron does — every user has hit Return / Enter / Esc to back out of something, and the glyph reads as "that".

## Change

`internal_filesystem/lib/mpos/ui/gesture_navigation.py:136`:

```diff
-    backlabel.set_text(lv.SYMBOL.LEFT)
+    backlabel.set_text(lv.SYMBOL.NEW_LINE)
```

Plus an inline comment explaining the choice. Font stays at `lv.font_montserrat_18`.

## Why this is safe

- **Same font range**: `lv.SYMBOL.NEW_LINE` is already used in `mpos/ui/keyboard.py` for the on-screen keyboard's Enter key (lines 53, 65, 77, 89 and the handler at 200). If the FA range weren't present in the bundled Montserrat, the keyboard's Enter glyph would already be tofu — so the back button using the same range adds no new font dependency.
- **Single render path**: only one back-button widget is created per gesture-nav setup, used for the swipe-from-left-edge interaction. No other consumer.

## Test plan

- [ ] Build a fresh firmware with this change, flash, swipe in from the left edge of any screen — confirm the ↵ glyph renders cleanly at montserrat_18 weight.
- [x] Static review: no other `lv.SYMBOL.LEFT` reference in gesture_navigation.py.
- [x] FA range availability confirmed via existing keyboard.py usage.