### PR TITLE
Focus: defer focus border until first directional navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Builtin Apps:
 - OSUpdate: show raw ESP error and a user-friendly message when the update fails to activate
 
 Frameworks:
+- Focus: `add_focus_border()` highlights now stay hidden until the user navigates by direction (joystick/keypad). The widget is still added to the focus group, but the border is only drawn from the first `move_focus_direction()` onward. Touch-only UIs (which focus widgets by tapping) never show a stray ring — e.g. the gold rectangle that appeared around the Lightning Piggy balance after tapping it — while keypad/encoder navigation is unchanged.
 - AppManager: add support for apps as Python packages 
 - Strip trailing slashes from directory paths before filesystem calls to support both LittleFS and FAT32 (SD card)
 - SDCard: tolerate trailing slashes when listing SD card contents

--- a/internal_filesystem/lib/mpos/ui/focus.py
+++ b/internal_filesystem/lib/mpos/ui/focus.py
@@ -1,7 +1,26 @@
 import lvgl as lv
 
 
+# Focus borders highlight which widget directional (keypad/joystick) focus is
+# on. They must stay invisible until the user actually navigates by direction,
+# so a touch-only UI — where widgets are focused by tapping — never shows a
+# stray highlight, and a hybrid touch+keypad device only shows it once the
+# joystick is used. move_focus_direction() flips this on first use via
+# enable_focus_borders().
+_focus_nav_active = False
+
+
+def enable_focus_borders():
+    """Mark that the user has navigated by direction (joystick/keypad). From
+    then on, focused widgets draw their focus border."""
+    global _focus_nav_active
+    _focus_nav_active = True
+
+
 def _focus_border_handler(event, width, color, opacity, radius):
+    if not _focus_nav_active:
+        # No directional navigation yet (e.g. touch-only use): no highlight.
+        return
     target = event.get_target_obj()
     target.set_style_border_color(color, lv.PART.MAIN)
     target.set_style_border_width(width, lv.PART.MAIN)
@@ -18,7 +37,12 @@ def _defocus_border_handler(event):
 
 
 def add_focus_border(widget, width=1, color=None, opacity=None, radius=None):
-    """Register focus/defocus callbacks that draw a border around a widget."""
+    """Register focus/defocus callbacks that draw a border around a widget.
+
+    The widget is always added to the focus group, but the border stays
+    invisible until the user navigates by direction (see enable_focus_borders
+    / move_focus_direction) — keeping the highlight off touch-only UIs while
+    preserving it for keypad/encoder navigation."""
     if color is None:
         color = lv.theme_get_color_primary(None)
     widget.add_event_cb(

--- a/internal_filesystem/lib/mpos/ui/focus_direction.py
+++ b/internal_filesystem/lib/mpos/ui/focus_direction.py
@@ -320,6 +320,12 @@ def find_closest_obj_in_direction(focus_group, current_focused, direction_degree
 # ---------------------------------------------------------------------------
 
 def move_focus_direction(angle):
+    # First directional navigation enables focus borders (see mpos.ui.focus):
+    # they stay hidden during touch-only use and appear once the joystick/keypad
+    # is actually used, so the highlight follows real navigation rather than
+    # device capability.
+    from .focus import enable_focus_borders
+    enable_focus_borders()
     focus_group = lv.group_get_default()
     if not focus_group:
         logger.warning("move_focus_direction: no default focus_group found, returning...")

--- a/tests/test_focus_border_deferred.py
+++ b/tests/test_focus_border_deferred.py
@@ -1,0 +1,74 @@
+"""
+Unit test for mpos.ui.focus deferred focus borders.
+
+A focus border highlights which widget directional (keypad/joystick) focus is
+on. It must not be drawn until the user actually navigates by direction, so a
+touch-only UI (widgets focused by tapping) never shows a stray ring. Borders
+are enabled on the first move_focus_direction() via enable_focus_borders();
+_focus_border_handler() is a no-op until then.
+
+Usage:
+    ./tests/unittest.sh tests/test_focus_border_deferred.py
+"""
+
+import unittest
+
+from mpos.ui import focus
+
+
+class _FakeTarget:
+    def __init__(self):
+        self.border_widths = []
+
+    def set_style_border_color(self, *a):
+        pass
+
+    def set_style_border_width(self, w, *a):
+        self.border_widths.append(w)
+
+    def set_style_border_opa(self, *a):
+        pass
+
+    def set_style_radius(self, *a):
+        pass
+
+    def scroll_to_view(self, *a):
+        pass
+
+
+class _FakeEvent:
+    def __init__(self, target):
+        self._target = target
+
+    def get_target_obj(self):
+        return self._target
+
+
+class TestDeferredFocusBorder(unittest.TestCase):
+    def setUp(self):
+        self._orig = focus._focus_nav_active
+        focus._focus_nav_active = False
+
+    def tearDown(self):
+        focus._focus_nav_active = self._orig
+
+    def test_no_border_before_directional_nav(self):
+        t = _FakeTarget()
+        focus._focus_border_handler(_FakeEvent(t), 1, None, None, None)
+        self.assertEqual(
+            t.border_widths, [],
+            "no border should be drawn before directional navigation",
+        )
+
+    def test_border_after_enable(self):
+        focus.enable_focus_borders()
+        t = _FakeTarget()
+        focus._focus_border_handler(_FakeEvent(t), 2, None, None, None)
+        self.assertEqual(
+            t.border_widths, [2],
+            "border should be drawn once focus navigation is enabled",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Keep focus borders hidden until the user actually navigates by direction (joystick/keypad).

## Why
`add_focus_border()` draws a focus highlight and adds the widget to the default focus group. That highlight is a navigation aid for **keypad/encoder** devices, showing which widget the moving focus is on. On a **pointer/touch** UI there is no moving highlight: the ring only appears after a tap and then lingers around the tapped widget.

Concretely, this is why the Lightning Piggy balance shows a gold rectangle after you tap it (the balance is `add_focus_border`-ed, and tapping it cycles the denomination). On a touchscreen that ring is visual noise rather than a cue.

## What
Per review feedback below, this is **input-driven rather than capability-driven**. Every widget is still added to the focus group; only the drawing of the border is deferred:

- `mpos/ui/focus.py`: module flag `_focus_nav_active` (starts `False`) plus `enable_focus_borders()`. `_focus_border_handler()` returns early while the flag is `False`, so no border is drawn.
- `mpos/ui/focus_direction.py`: `move_focus_direction()` calls `enable_focus_borders()` at the top, so the first joystick/keypad press flips it on and the resulting `FOCUSED` event draws the border as normal.

Resulting behavior:

| device | result |
| --- | --- |
| touch only (focus by tapping) | never shows a ring |
| keypad/encoder | ring appears as soon as they navigate |
| hybrid touch + keypad | ring appears only once the joystick is actually used |

The hybrid case is the reason for this approach over the first version of this PR, which skipped `add_focus_border()` entirely when a pointer indev was present and so would have wrongly suppressed the ring on hybrid devices. `add_focus_border()` itself is back to its original shape, with no capability check, making this a smaller change than that first version.

## Testing
- `tests/test_focus_border_deferred.py` added: asserts no border is drawn before directional navigation, and that a border is drawn after `enable_focus_borders()`.
- Verified both states in a CPython stub harness (lvgl stubbed): passes.
- Caveat, stated plainly: I did **not** run `./tests/unittest.sh` locally, since it needs a freshly built desktop binary and my local build is stale. Please run `./tests/unittest.sh tests/test_focus_border_deferred.py` in CI or on a current build.

## Merge checklist
- CHANGELOG: added under Future release, Frameworks
- App version / MANIFEST: n/a (framework change)
- MAINTAINERS.md / boards: n/a
- Settings migration: n/a
- Unit tests: added, see the testing caveat above
- Frameworks docs (docs.micropythonos.com): not updated. `add_focus_border` behavior is now state-dependent, so happy to add a note if there is a docs page covering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
