### PR TITLE
fix(net): wait_until_online() never actually waits (always-truthy bug)

### DIFF
--- a/internal_filesystem/lib/mpos/net/connectivity_manager.py
+++ b/internal_filesystem/lib/mpos/net/connectivity_manager.py
@@ -116,7 +116,7 @@ class ConnectivityManager:
              return True
          start = time.time()
          while time.time() - start < timeout:
-             if self.is_online:
+             if self.is_online():
                  return True
              time.sleep(1)
          return False

--- a/tests/test_connectivity_manager.py
+++ b/tests/test_connectivity_manager.py
@@ -399,6 +399,16 @@ class TestConnectivityManagerWaitUntilOnline(unittest.TestCase):
         result = cm.wait_until_online(timeout=5)
         self.assertTrue(result)
 
+    def test_wait_until_online_offline_returns_false(self):
+        """Offline must NOT return True early: regression for the is_online bound-method bug."""
+        self.mock_network.set_connected(False)
+        cm = self.ConnectivityManager()
+        self.assertFalse(cm.is_online())
+        # With the bug (`if self.is_online:`) this returned True instantly;
+        # fixed (`if self.is_online():`) it must wait and return False.
+        result = cm.wait_until_online(timeout=0.5)
+        self.assertFalse(result)
+
     def test_wait_until_online_without_network_module(self):
         """Test wait_until_online without network module (desktop)."""
         # Remove network module


### PR DESCRIPTION
## Summary

`ConnectivityManager.wait_until_online()` has a bug that makes it return `True`
immediately even when the device is offline, so it never actually waits.

```python
def wait_until_online(self, timeout=60):
    if not self.can_check_network:
        return True
    start = time.time()
    while time.time() - start < timeout:
        if self.is_online:        # <-- bug: is_online is a METHOD
            return True
        time.sleep(1)
    return False
```

`is_online` is a method (`def is_online(self): return self._is_online`), so
`if self.is_online:` tests a bound-method object, which is **always truthy**.
The loop returns `True` on its first iteration regardless of actual connectivity.

## Fix

Call the method:

```python
        if self.is_online():
            return True
```

One-line change. Any caller relying on `wait_until_online()` to block until
connectivity is restored now behaves correctly.

## Test

Added an offline regression test to the existing `TestConnectivityManagerWaitUntilOnline`
class. With a disconnected mock network, `wait_until_online(timeout=0.5)` must return
`False` (it returned `True` instantly before the fix):

```
$ ./tests/unittest.sh tests/test_connectivity_manager.py
Ran 26 tests
OK
```

ASCII-only, no new dependencies.