### PR TITLE
fix(net): aiohttp header-read timeout + mutable-header poisoning + atomic wifi_busy

### DIFF
--- a/internal_filesystem/lib/aiohttp/__init__.py
+++ b/internal_filesystem/lib/aiohttp/__init__.py
@@ -107,11 +107,11 @@ class _RequestContextManager:
 
 
 class ClientSession:
-    def __init__(self, base_url="", headers={}, version=HttpVersion10):
+    def __init__(self, base_url="", headers=None, version=HttpVersion10):
         self._reader = None
         self._base_url = base_url
         self._base_headers = {"Connection": "close", "User-Agent": "compat"}
-        self._base_headers.update(**headers)
+        self._base_headers.update(**(headers or {}))
         self._http_version = version
 
     async def __aenter__(self):
@@ -122,26 +122,40 @@ class ClientSession:
 
     # Connection timeout is supported via the timeout parameter on request methods
 
-    async def _request(self, method, url, data=None, json=None, ssl=None, params=None, headers={}, timeout=None):
+    async def _request(self, method, url, data=None, json=None, ssl=None, params=None, headers=None, timeout=None):
+        if headers is None:
+            headers = {}
         redir_cnt = 0
         while redir_cnt < 2:
             reader = await self.request_raw(method, url, data, json, ssl, params, headers, timeout=timeout)
-            _headers = []
-            redirect_location = None
-            sline = await reader.readline()
-            sline = sline.split(None, 2)
-            status = int(sline[1])
-            chunked = False
-            while True:
-                line = await reader.readline()
-                if not line or line == b"\r\n":
-                    break
-                _headers.append(line)
-                if line.startswith(b"Transfer-Encoding:"):
-                    if b"chunked" in line:
-                        chunked = True
-                elif line.startswith(b"Location:"):
-                    redirect_location = line.rstrip().split(None, 1)[1].decode()
+
+            async def _read_head():
+                _headers = []
+                redirect_location = None
+                sline = await reader.readline()
+                sline = sline.split(None, 2)
+                status = int(sline[1])
+                chunked = False
+                while True:
+                    line = await reader.readline()
+                    if not line or line == b"\r\n":
+                        break
+                    _headers.append(line)
+                    if line.startswith(b"Transfer-Encoding:"):
+                        if b"chunked" in line:
+                            chunked = True
+                    elif line.startswith(b"Location:"):
+                        redirect_location = line.rstrip().split(None, 1)[1].decode()
+                return status, _headers, chunked, redirect_location
+
+            # Bound the status-line + header read by the same timeout as connect, so
+            # a server that accepts the connection then stalls before/while sending
+            # headers cannot hang the event loop (and the UI) forever. Body reads are
+            # bounded by the caller (e.g. DownloadManager's per-chunk timeout).
+            if timeout is not None:
+                status, _headers, chunked, redirect_location = await asyncio.wait_for(_read_head(), timeout)
+            else:
+                status, _headers, chunked, redirect_location = await _read_head()
 
             if 301 <= status <= 303:
                 if redirect_location:
@@ -220,11 +234,15 @@ class ClientSession:
         json=None,
         ssl=None,
         params=None,
-        headers={},
+        headers=None,
         is_handshake=False,
         version=None,
         timeout=None,
     ):
+        # Copy into a fresh dict: this method mutates headers in place (Host,
+        # Content-Type, Content-Length), so mutating a caller-shared dict would
+        # poison later requests.
+        headers = dict(headers) if headers else {}
         if json and isinstance(json, dict):
             data = _json.dumps(json)
         if data is not None and method == "GET":
@@ -294,7 +312,7 @@ class ClientSession:
             await writer.awrite(query)
             return reader, writer
 
-    def request(self, method, url, data=None, json=None, ssl=None, params=None, headers={}, timeout=None):
+    def request(self, method, url, data=None, json=None, ssl=None, params=None, headers=None, timeout=None):
         return _RequestContextManager(
             self,
             self._request(
@@ -304,7 +322,7 @@ class ClientSession:
                 json=json,
                 ssl=ssl,
                 params=params,
-                headers=dict(**self._base_headers, **headers),
+                headers=dict(**self._base_headers, **(headers or {})),
                 timeout=timeout,
             ),
         )

--- a/internal_filesystem/lib/mpos/net/wifi_service.py
+++ b/internal_filesystem/lib/mpos/net/wifi_service.py
@@ -10,6 +10,7 @@ Manages WiFi connections including:
 This service works alongside ConnectivityManager which monitors connection status.
 """
 
+import _thread
 import logging
 import time
 
@@ -42,6 +43,11 @@ class WifiService:
     # Class-level lock to prevent concurrent WiFi operations
     # Use is_busy() to check state; operations like scan_networks() manage this automatically
     wifi_busy = False
+
+    # Guards the check-then-set of wifi_busy so two threads (e.g. the boot
+    # auto-connect thread and the WiFi app) cannot both observe wifi_busy=False
+    # and proceed -> double-connect. Acquire via _acquire_busy().
+    _busy_lock = _thread.allocate_lock()
 
     # Dictionary of saved access points {ssid: {password: "..."}}
     access_points = {}
@@ -315,6 +321,20 @@ class WifiService:
             return False
 
     @staticmethod
+    def _acquire_busy():
+        """Atomically claim the wifi_busy flag.
+
+        Returns True if the flag was free and is now held by the caller, False
+        if another operation already holds it. Pairs the check and the set under
+        _busy_lock so concurrent threads cannot both proceed.
+        """
+        with WifiService._busy_lock:
+            if WifiService.wifi_busy:
+                return False
+            WifiService.wifi_busy = True
+            return True
+
+    @staticmethod
     def auto_connect(network_module=None, time_module=None):
         """
         Auto-connect to a saved WiFi network on boot.
@@ -347,13 +367,13 @@ class WifiService:
             if __debug__: logger.debug("No access points configured, exiting")
             return
 
-        # Check if WiFi is busy (e.g., WiFi app is scanning)
-        if WifiService.wifi_busy:
+        # Atomically claim the busy flag (e.g. WiFi app may be scanning). If
+        # another operation holds it, abort instead of racing into a connect.
+        if not WifiService._acquire_busy():
             WifiService._restore_hotspot_if_needed(network_module=network_module)
             if __debug__: logger.debug("WiFi busy, auto-connect aborted")
             return
 
-        WifiService.wifi_busy = True
         connected = False
 
         try:
@@ -404,7 +424,9 @@ class WifiService:
         Raises:
             RuntimeError: If WiFi operations are already in progress
         """
-        if WifiService.wifi_busy:
+        # Atomically claim the busy flag so a concurrent auto-connect cannot slip
+        # in between the check and the set below.
+        if not WifiService._acquire_busy():
             raise RuntimeError("Cannot disable WiFi: WifiService is already busy")
 
         was_connected = False
@@ -424,8 +446,7 @@ class WifiService:
             "hotspot_was_enabled": hotspot_was_enabled,
         }
 
-        # Now set busy flag and disconnect
-        WifiService.wifi_busy = True
+        # Busy flag already claimed atomically above; now disconnect.
         WifiService.disconnect(network_module=network_module)
 
         return was_connected


### PR DESCRIPTION
A small batch of networking robustness fixes (maintainer shortlist).

### 1. aiohttp: stalled server can hang the loop/UI forever
`_request`'s timeout covered only DNS+connect; the status-line and response-header
`readline()` reads were unbounded. A server that accepts the connection then stalls
before/while sending headers froze the asyncio event loop (and the LVGL UI) forever.
The header read is now wrapped in the same `wait_for(timeout)`. Body reads remain the
caller's responsibility (`DownloadManager` already bounds per-chunk reads).

### 2. aiohttp: mutable-default `headers={}` poisoning
The four `headers={}` default parameters are now `headers=None`, and `request_raw`
copies the dict before mutating it (`Host`/`Content-Type`/`Content-Length`) — so a
caller-shared headers dict can no longer be poisoned across requests.

### 3. WifiService: `wifi_busy` check-then-set race
`auto_connect()` and `temporarily_disable()` each tested `wifi_busy` then set it in
separate statements. Two threads (boot auto-connect + the WiFi app) could both see
`wifi_busy=False` and proceed → double-connect. Added a `_busy_lock` + `_acquire_busy()`
helper that does the check-and-set atomically, used at both sites.

### Testing (macOS sim)
- New stall test: with a server that connects but never sends headers, `_request(timeout=1)`
  now raises `TimeoutError` at ~1.0s instead of hanging (verified old path would hang).
- Header isolation: two `ClientSession`s with different default headers stay isolated.
- Existing suites: `test_websocket` OK, `test_async_dns` OK, `test_wifi_service` 46/46 OK.
- `mpy-cross` compiles both files on this branch's base; ASCII-only.

Independent of #177 (touches different regions of `aiohttp/__init__.py`).