### PR TITLE
Extract inlined Python from build_mpos.sh into separate file

### DIFF
--- a/scripts/build_mpos.sh
+++ b/scripts/build_mpos.sh
@@ -258,18 +258,7 @@ elif [ "$target" == "unix" -o "$target" == "macOS" ]; then
 		local name="$1"
 		if ! grep -q "$name" "$mpconfig_unix"; then
 			echo "Enabling $name in $mpconfig_unix"
-			python3 - "$mpconfig_unix" "$name" <<'PY'
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-name = sys.argv[2]
-text = path.read_text()
-needle = '#include "mpconfigvariant.h"'
-insert = f"\n\n#ifndef {name}\n#define {name} (1)\n#endif\n"
-if needle in text and name not in text:
-	path.write_text(text.replace(needle, needle + insert))
-PY
+			python3 "$mydir"/ensure_mpconfig_define.py "$mpconfig_unix" "$name"
 		else
 			echo "$name already configured in $mpconfig_unix"
 		fi

--- a/scripts/ensure_mpconfig_define.py
+++ b/scripts/ensure_mpconfig_define.py
@@ -1,0 +1,19 @@
+"""Insert a `#define <NAME> (1)` into a MicroPython mpconfigport.h.
+
+Usage: ensure_mpconfig_define.py <mpconfigport.h> <DEFINE_NAME>
+
+Adds the define right after the `#include "mpconfigvariant.h"` line, guarded
+by an #ifndef so it doesn't clash with an existing definition. No-op if the
+include isn't present or the name already appears in the file.
+"""
+
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+name = sys.argv[2]
+text = path.read_text()
+needle = '#include "mpconfigvariant.h"'
+insert = f"\n\n#ifndef {name}\n#define {name} (1)\n#endif\n"
+if needle in text and name not in text:
+    path.write_text(text.replace(needle, needle + insert))


### PR DESCRIPTION
Move the mpconfigport.h define-insertion heredoc out of build_mpos.sh and into scripts/ensure_mpconfig_define.py, per maintainer review feedback.