### PR TITLE
Extract inline Python heredoc from build_mpos.sh

### DIFF
--- a/scripts/build_mpos.sh
+++ b/scripts/build_mpos.sh
@@ -258,18 +258,7 @@ elif [ "$target" == "unix" -o "$target" == "macOS" ]; then
 		local name="$1"
 		if ! grep -q "$name" "$mpconfig_unix"; then
 			echo "Enabling $name in $mpconfig_unix"
-			python3 - "$mpconfig_unix" "$name" <<'PY'
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-name = sys.argv[2]
-text = path.read_text()
-needle = '#include "mpconfigvariant.h"'
-insert = f"\n\n#ifndef {name}\n#define {name} (1)\n#endif\n"
-if needle in text and name not in text:
-	path.write_text(text.replace(needle, needle + insert))
-PY
+			python3 "$mydir"/ensure_mpconfig_define.py "$mpconfig_unix" "$name"
 		else
 			echo "$name already configured in $mpconfig_unix"
 		fi

--- a/scripts/ensure_mpconfig_define.py
+++ b/scripts/ensure_mpconfig_define.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Insert a `#define <name> (1)` guard into a MicroPython mpconfigport.h.
+
+Used by build_mpos.sh to enable build-time options (e.g. MICROPY_PY_WEBREPL,
+MICROPY_PY_OS_DUPTERM) for the unix/macOS ports. The define is inserted right
+after the `#include "mpconfigvariant.h"` line, and only if not already present.
+
+Usage: ensure_mpconfig_define.py <mpconfigport.h path> <DEFINE_NAME>
+"""
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+name = sys.argv[2]
+text = path.read_text()
+needle = '#include "mpconfigvariant.h"'
+insert = f"\n\n#ifndef {name}\n#define {name} (1)\n#endif\n"
+if needle in text and name not in text:
+    path.write_text(text.replace(needle, needle + insert))


### PR DESCRIPTION
Move the mpconfigport.h define-insertion logic out of the inline `python3 - <<'PY'` heredoc in `ensure_mpconfig_define()` into a standalone `scripts/ensure_mpconfig_define.py`, called with the same two arguments. Behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)