### PR TITLE
fix(net): resume downloads after a mid-stream connection drop

### DIFF
--- a/internal_filesystem/lib/mpos/net/download_manager.py
+++ b/internal_filesystem/lib/mpos/net/download_manager.py
@@ -196,148 +196,158 @@ class DownloadManager:
         try:
             headers = cls._merge_headers(headers)
             
-            async with session.get(url, headers=headers, ssl=sslctx, timeout=_CHUNK_TIMEOUT_SECONDS) as response:
-                if response.status < 200 or response.status >= 400:
-                    logger.error("HTTP error %s", response.status)
-                    raise RuntimeError(f"HTTP {response.status}")
-                
-                # Figure out total size and starting offset (for resume support)
-                # When redacting, suppress the headers dump entirely — response
-                # headers can include `set-cookie`, `cf-ray` and other tokens
-                # that correlate to the request's secret-bearing URL.
-                if redact_url:
-                    if __debug__: logger.debug("Response headers: <redacted>")
-                else:
-                    if __debug__: logger.debug("Response headers: %s", response.headers)
-                resume_offset = 0  # Starting byte offset (0 for new downloads, >0 for resumed)
-                
-                if total_size is None:
-                    # response.headers is a dict (after parsing) or None/list (before parsing)
-                    try:
-                        if isinstance(response.headers, dict):
-                            # Check for Content-Range first (used when resuming with Range header)
-                            # Format: 'bytes 1323008-3485807/3485808'
-                            # START is the resume offset, TOTAL is the complete file size
-                            content_range = response.headers.get('Content-Range')
-                            if content_range:
-                                # Parse total size and starting offset from Content-Range header
-                                # Example: 'bytes 1323008-3485807/3485808' -> offset=1323008, total=3485808
-                                if '/' in content_range and ' ' in content_range:
-                                    # Extract the range part: '1323008-3485807'
-                                    range_part = content_range.split(' ')[1].split('/')[0]
-                                    # Extract starting offset
-                                    resume_offset = int(range_part.split('-')[0])
-                                    # Extract total size
-                                    total_size = int(content_range.split('/')[-1])
-                                    if __debug__: logger.debug("Resuming from byte %s, total size: %s", resume_offset, total_size)
-                            
-                            # Fall back to Content-Length if Content-Range not present
+            # State that must survive a reconnect. On a mid-stream connection
+            # drop we re-issue the request with a Range header from partial_size
+            # and keep writing to the same fd, so a flaky link resumes the
+            # download instead of aborting it.
+            from mpos import TaskManager
+            chunks = []
+            chunk_size = _DEFAULT_CHUNK_SIZE
+            partial_size = None   # absolute byte offset reached so far (None = no connection yet)
+            last_progress_pct = -1.0
+            speed_bytes_since_last_update = 0
+            speed_last_update_time = None
+            try:
+                import time
+                speed_last_update_time = time.ticks_ms()
+            except ImportError:
+                pass  # time module not available
+
+            reconnects_left = _MAX_RETRIES
+            while True:
+                attempt_headers = dict(headers)
+                resuming = partial_size is not None
+                if resuming:
+                    # Resume from where the stream dropped. A server that supports
+                    # ranges replies 206; one that does not replies 200 (handled below).
+                    attempt_headers['Range'] = 'bytes=%d-' % partial_size
+
+                reconnect_needed = False
+                async with session.get(url, headers=attempt_headers, ssl=sslctx, timeout=_CHUNK_TIMEOUT_SECONDS) as response:
+                    if response.status < 200 or response.status >= 400:
+                        logger.error("HTTP error %s", response.status)
+                        raise RuntimeError(f"HTTP {response.status}")
+
+                    if resuming:
+                        # A 206 is required to safely append; a 200 means the server
+                        # ignored Range and would resend from the start (can't resume).
+                        if response.status != 206:
+                            raise OSError(-110, "Server does not support resume (HTTP %s)" % response.status)
+                    else:
+                        # ---- one-time setup, runs only on the first connection ----
+                        # When redacting, suppress the headers dump entirely - response
+                        # headers can include set-cookie / cf-ray tokens that correlate
+                        # to a secret-bearing URL.
+                        if redact_url:
+                            if __debug__: logger.debug("Response headers: <redacted>")
+                        else:
+                            if __debug__: logger.debug("Response headers: %s", response.headers)
+                        resume_offset = 0  # Starting byte offset (0 for new downloads, >0 for caller-resumed)
+
+                        if total_size is None:
+                            # response.headers is a dict (after parsing) or None/list (before parsing)
+                            try:
+                                if isinstance(response.headers, dict):
+                                    # Content-Range wins (caller-side resume): 'bytes 1323008-3485807/3485808'
+                                    content_range = response.headers.get('Content-Range')
+                                    if content_range:
+                                        if '/' in content_range and ' ' in content_range:
+                                            range_part = content_range.split(' ')[1].split('/')[0]
+                                            resume_offset = int(range_part.split('-')[0])
+                                            total_size = int(content_range.split('/')[-1])
+                                            if __debug__: logger.debug("Resuming from byte %s, total size: %s", resume_offset, total_size)
+                                    # Fall back to Content-Length if Content-Range absent
+                                    if total_size is None:
+                                        content_length = response.headers.get('Content-Length')
+                                        if content_length:
+                                            total_size = int(content_length)
+                                            if __debug__: logger.debug("Using Content-Length: %s", total_size)
+                            except (AttributeError, TypeError, ValueError, IndexError) as e:
+                                logger.error("Could not parse Content-Range/Content-Length: %s", e)
                             if total_size is None:
-                                content_length = response.headers.get('Content-Length')
-                                if content_length:
-                                    total_size = int(content_length)
-                                    if __debug__: logger.debug("Using Content-Length: %s", total_size)
-                    except (AttributeError, TypeError, ValueError, IndexError) as e:
-                        logger.error("Could not parse Content-Range/Content-Length: %s", e)
-                    
-                    if total_size is None:
-                        logger.warning("Unable to determine total_size, assuming %s bytes", _DEFAULT_TOTAL_SIZE)
-                        total_size = _DEFAULT_TOTAL_SIZE
-                
-                # Setup output
-                if outfile:
-                    fd = open(outfile, 'wb')
-                    if not fd:
-                        logger.warning("Could not open %s for writing!", outfile)
-                        return False
-                
-                chunks = []
-                partial_size = resume_offset  # Start from resume offset for accurate progress
-                chunk_size = _DEFAULT_CHUNK_SIZE
-                
-                # Progress tracking with 2-decimal precision
-                last_progress_pct = -1.0  # Track last reported progress to avoid duplicates
-                
-                # Speed tracking
-                speed_bytes_since_last_update = 0
-                speed_last_update_time = None
-                try:
-                    import time
-                    speed_last_update_time = time.ticks_ms()
-                except ImportError:
-                    pass  # time module not available
-                
-                if __debug__: logger.debug("Downloading %s bytes in chunks of size %s", total_size, chunk_size)
-                
-                # Download loop with retry logic
-                while True:
-                    tries_left = _MAX_RETRIES
-                    chunk_data = None
-                    while tries_left > 0:
+                                logger.warning("Unable to determine total_size, assuming %s bytes", _DEFAULT_TOTAL_SIZE)
+                                total_size = _DEFAULT_TOTAL_SIZE
+
+                        # Setup output
+                        if outfile:
+                            fd = open(outfile, 'wb')
+                            if not fd:
+                                logger.warning("Could not open %s for writing!", outfile)
+                                return False
+
+                        partial_size = resume_offset  # Start from resume offset for accurate progress
+                        if __debug__: logger.debug("Downloading %s bytes in chunks of size %s", total_size, chunk_size)
+
+                    # ---- read this connection until EOF or a read error ----
+                    while True:
                         try:
-                            # Import TaskManager here to avoid circular imports
-                            from mpos import TaskManager
                             chunk_data = await TaskManager.wait_for(
                                 response.content.read(chunk_size),
                                 _CHUNK_TIMEOUT_SECONDS
                             )
-                            break
                         except Exception as e:
+                            # A read error (timeout / dropped connection) is recoverable:
+                            # break out and resume via a Range request below.
                             logger.error("Chunk read error: %s", e)
-                            tries_left -= 1
-                    
-                    if tries_left == 0:
-                        logger.error("Failed to download chunk after retries")
-                        if fd:
-                            fd.close()
-                        raise OSError(-110, "Failed to download chunk after retries")
-                    
-                    if chunk_data:
-                        # Output chunk
+                            reconnect_needed = True
+                            break
+
+                        if not chunk_data:
+                            # Chunk is empty, download complete
+                            if __debug__: logger.debug("Finished downloading %s", log_url)
+                            if fd:
+                                fd.close()
+                                fd = None
+                                return True
+                            elif chunk_callback:
+                                return True
+                            else:
+                                return b''.join(chunks)
+
+                        # Output chunk. Write/callback errors propagate - they are not
+                        # connection problems, so they must not trigger a reconnect.
                         if fd:
                             fd.write(chunk_data)
                         elif chunk_callback:
                             await chunk_callback(chunk_data)
                         else:
                             chunks.append(chunk_data)
-                        
+
                         # Track bytes for speed calculation
                         chunk_len = len(chunk_data)
                         partial_size += chunk_len
                         speed_bytes_since_last_update += chunk_len
-                        
-                        # Report progress with 2-decimal precision
-                        # Only call callback if progress changed by at least 0.01%
+
+                        # Report progress with 2-decimal precision (only on change)
                         progress_pct = round((partial_size * 100) / int(total_size), 2)
                         if progress_callback and progress_pct != last_progress_pct:
                             if __debug__: logger.debug("Progress: %s / %s bytes = %s%%", partial_size, total_size, progress_pct)
                             await progress_callback(progress_pct)
                             last_progress_pct = progress_pct
-                        
+
                         # Report speed periodically
                         if speed_callback and speed_last_update_time is not None:
                             import time
                             current_time = time.ticks_ms()
                             elapsed_ms = time.ticks_diff(current_time, speed_last_update_time)
                             if elapsed_ms >= _SPEED_UPDATE_INTERVAL_MS:
-                                # Calculate bytes per second
                                 bytes_per_second = (speed_bytes_since_last_update * 1000) / elapsed_ms
                                 if __debug__: logger.debug("Speed: %s B/s", bytes_per_second)
                                 await speed_callback(bytes_per_second)
-                                # Reset for next interval
                                 speed_bytes_since_last_update = 0
                                 speed_last_update_time = current_time
-                    else:
-                        # Chunk is None, download complete
-                        if __debug__: logger.debug("Finished downloading %s", log_url)
-                        if fd:
-                            fd.close()
-                            fd = None
-                            return True
-                        elif chunk_callback:
-                            return True
-                        else:
-                            return b''.join(chunks)
+
+                # Connection ended without reaching EOF. Resume if we have budget.
+                if not reconnect_needed:
+                    break  # defensive: read loop only exits via return or reconnect
+                reconnects_left -= 1
+                if reconnects_left <= 0:
+                    logger.error("Failed to download chunk after retries")
+                    if fd:
+                        fd.close()
+                    raise OSError(-110, "Failed to download chunk after retries")
+                if __debug__: logger.warning("Connection lost at %s/%s bytes, resuming...", partial_size, total_size)
+                await TaskManager.sleep_ms(200)
         
         except Exception as e:
             # Exception strings from aiohttp often embed the full URL —

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -801,3 +801,133 @@ class TestRedactedExceptionPath(unittest.TestCase):
             any("...REDACTED..." in l for l in exc_lines),
             "default behaviour should not insert REDACTED placeholder; "
             "got lines: {}".format(exc_lines))
+
+
+class TestDownloadResumeOnConnectionDrop(unittest.TestCase):
+    """A mid-stream connection drop must be recovered by reconnecting with a
+    Range header and resuming, not by failing the whole download.
+
+    Installs a fake aiohttp (via sys.modules, like TestRedactedExceptionPath)
+    whose first connection delivers part of the payload then raises on the next
+    read (simulating ECONNRESET). The reconnect carries `Range: bytes=<n>-` and
+    the fake serves the remainder as a 206. The reassembled file must equal the
+    full payload.
+    """
+
+    def setUp(self):
+        self.temp_dir = "/tmp/test_download_manager"
+        try:
+            os.mkdir(self.temp_dir)
+        except OSError:
+            pass
+
+    def _run_with_fake_aiohttp(self, *, payload, drop_after, outfile):
+        import asyncio
+        import sys
+
+        ranges = []
+
+        class _FakeContent:
+            def __init__(self, buf, drop):
+                self._buf = buf
+                self._pos = 0
+                self._drop = drop
+                self._delivered = 0
+
+            async def read(self, n):
+                if self._drop is not None and self._delivered >= self._drop:
+                    raise OSError(-104, "ECONNRESET")
+                chunk = self._buf[self._pos:self._pos + n]
+                self._pos += len(chunk)
+                self._delivered += len(chunk)
+                return chunk  # b'' at EOF
+
+        class _FakeResp:
+            def __init__(self, status, headers, content):
+                self.status = status
+                self.headers = headers
+                self.content = content
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        class _FakeClientSession:
+            def get(self, request_url, headers=None, **kwargs):
+                rng = (headers or {}).get("Range")
+                ranges.append(rng)
+                if rng is None:
+                    return _FakeResp(200,
+                                     {"Content-Length": str(len(payload))},
+                                     _FakeContent(payload, drop_after))
+                start = int(rng.split("=")[1].split("-")[0])
+                hdrs = {"Content-Range":
+                        "bytes %d-%d/%d" % (start, len(payload) - 1, len(payload))}
+                return _FakeResp(206, hdrs, _FakeContent(payload[start:], None))
+
+            async def close(self):
+                pass
+
+        class _FakeAiohttp:
+            pass
+
+        fake_aiohttp = _FakeAiohttp()
+        fake_aiohttp.ClientSession = _FakeClientSession
+
+        old_aiohttp = sys.modules.get("aiohttp")
+        sys.modules["aiohttp"] = fake_aiohttp
+        try:
+            async def _go():
+                return await DownloadManager._download_url_async(
+                    "http://fake.invalid/f.bin", outfile=outfile)
+            result = asyncio.run(_go())
+        finally:
+            if old_aiohttp is None:
+                try:
+                    del sys.modules["aiohttp"]
+                except KeyError:
+                    pass
+            else:
+                sys.modules["aiohttp"] = old_aiohttp
+
+        return result, ranges
+
+    def test_resumes_after_midstream_drop(self):
+        payload = bytes((i * 7) % 256 for i in range(12000))  # ~3 chunks of 4096
+        outfile = self.temp_dir + "/resume.bin"
+        try:
+            os.remove(outfile)
+        except OSError:
+            pass
+
+        result, ranges = self._run_with_fake_aiohttp(
+            payload=payload, drop_after=5000, outfile=outfile)
+
+        self.assertTrue(result)
+        # First request (no Range) + exactly one resume (Range).
+        self.assertEqual(len(ranges), 2)
+        self.assertIsNone(ranges[0])
+        self.assertIsNotNone(ranges[1])
+        self.assertTrue(ranges[1].startswith("bytes="))
+        with open(outfile, "rb") as f:
+            got = f.read()
+        self.assertEqual(got, payload)
+
+    def test_clean_download_uses_single_connection(self):
+        payload = bytes((i * 3) % 256 for i in range(9000))
+        outfile = self.temp_dir + "/clean.bin"
+        try:
+            os.remove(outfile)
+        except OSError:
+            pass
+
+        result, ranges = self._run_with_fake_aiohttp(
+            payload=payload, drop_after=None, outfile=outfile)
+
+        self.assertTrue(result)
+        self.assertEqual(ranges, [None])  # no reconnect, no Range used
+        with open(outfile, "rb") as f:
+            got = f.read()
+        self.assertEqual(got, payload)


### PR DESCRIPTION
Follow-up from the networking shortlist (the `download_manager.py:285` item).

### Problem
The per-chunk retry loop re-read the **same** aiohttp reader after a failure.
Once the underlying TCP/TLS connection dropped — common on flaky badge WiFi —
that reader was dead, so all 3 retries failed and the entire download aborted
with `OSError(-110)`. The resume infrastructure (`Range`/`Content-Range`,
`get_resume_position`) already existed but was never used on retry, so a blip
near the end of a large album/`.mpk` download threw away all progress.

### Fix
Restructure the read path into a **connection-retry loop**:
- On a read error, close the connection and re-issue the request with
  `Range: bytes=<partial_size>-`, continuing to write to the same `fd`.
- A server that supports ranges replies `206` → the download resumes from where
  it dropped. One that replies `200` (no range support) raises — same outcome as
  before, so no regression for those servers.
- Write/callback errors propagate immediately (they aren't connection problems,
  so they must not trigger a reconnect).
- Per-connection setup (status check, `Content-Range`/`Content-Length` parse,
  `fd` open) runs once on the first connection; reconnects skip it.
- Reconnect budget reuses `_MAX_RETRIES` (3).

### Testing
New `TestDownloadResumeOnConnectionDrop` (fake aiohttp via `sys.modules`, same
style as `TestRedactedExceptionPath`):
- `test_resumes_after_midstream_drop`: first connection drops at ~5 KB, the
  reconnect carries a `Range:` header, and the reassembled file equals the full
  12 KB payload (1 initial + 1 resume connection).
- `test_clean_download_uses_single_connection`: no drop → one connection, no
  `Range`, full payload.

Full suite: **36 tests OK** (34 existing + 2 new). `mpy-cross` compiles; ASCII-only.

Note: the maintainer's paired "fd not closed via try/finally" was verified to be
a false positive — `fd` is already closed on every path — so that part is a no-op.