### PR TITLE
test(nostr): gate live-relay integration test behind MPOS_RUN_NETWORK_TESTS

### DIFF
--- a/tests/test_nostr_nip17_self_send_real_relays.py
+++ b/tests/test_nostr_nip17_self_send_real_relays.py
@@ -7,6 +7,7 @@ filter, network, and relay-specific issues.
 """
 
 import asyncio
+import os
 import sys
 import time
 import unittest
@@ -32,6 +33,11 @@ _DEFAULT_RELAYS = [
 ]
 
 
+@unittest.skipUnless(
+    os.getenv("MPOS_RUN_NETWORK_TESTS"),
+    "live-relay integration test; depends on external relay uptime. "
+    "Set MPOS_RUN_NETWORK_TESTS=1 to run.",
+)
 class TestNip17SelfSendRealRelays(unittest.TestCase):
     """Send a NIP-17 message to yourself over the internet and verify receipt."""
 


### PR DESCRIPTION
`test_self_send_nip17_over_real_relays` opens **live** WebSocket connections to
public relays (`relay.damus.io`, `relay.primal.net`, `relay.0xchat.com`) and
waits for them to echo a NIP-17 gift-wrap back. So it fails whenever a relay has
a transient outage — and that's been reddening unrelated PRs' CI.

Recent runs (e.g. #182, which changes only `download_manager.py`):
```
wss://relay.damus.io   -> HTTP/1.1 520   (Cloudflare: origin unreachable)
wss://relay.0xchat.com -> HTTP/1.1 500
-> AssertionError: No kind-14 rumor … received within 45s
```
I re-checked both live afterward — back to **HTTP 200** (healthy). So these were
momentary relay-side outages (5xx), not a client/code problem.

### Change
Gate the test class behind `MPOS_RUN_NETWORK_TESTS` via `@unittest.skipUnless`:
- **CI (env unset):** the class is **skipped** → deterministic, no more flakiness
  from third-party relay uptime.
- **On demand:** `MPOS_RUN_NETWORK_TESTS=1 ./tests/unittest.sh tests/test_nostr_nip17_self_send_real_relays.py`
  runs it as before — handy for a dedicated/nightly network job.

Verified through `./tests/unittest.sh`: with the var unset the gated class reports
`skipped` and the suite exits `OK (skipped=1)` (exit 0); the harness still reports
real failures for un-gated tests, so nothing is masked. Minimal diff (`import os`
+ one decorator).

Context: this is the test that was failing on #177 — it's environmental, not the
DNS change.