### PR TITLE
feat(net): cache async DNS resolutions to reuse across requests

### DIFF
--- a/internal_filesystem/lib/mpos/net/async_dns.py
+++ b/internal_filesystem/lib/mpos/net/async_dns.py
@@ -25,6 +25,7 @@ Usage:
 import socket
 import _thread
 import sys
+import time
 from mpos.task_manager import TaskManager
 
 # Module-level reference to the getaddrinfo implementation.  Tests replace this
@@ -41,6 +42,31 @@ _getaddrinfo = socket.getaddrinfo
 _MAX_INFLIGHT = 2
 _inflight_lock = _thread.allocate_lock()
 _inflight = 0
+
+# Cache successful resolutions per (host, port, proto, socktype). Apps that
+# fetch many files from one host, or that repeatedly retry a relay connection,
+# would otherwise spawn a fresh resolver thread per lookup; on a thread-starved
+# ESP32-S3 a burst of those can exhaust the thread pool. A short TTL keeps
+# results fresh enough to follow DNS changes. Only successful lookups are cached
+# (errors must re-resolve).
+_DNS_CACHE_TTL_MS = 300_000  # 5 minutes
+_dns_cache = {}  # (host, port, proto, socktype) -> (result, resolved_ticks_ms)
+
+
+def clear_dns_cache():
+    """Drop all cached DNS results (call on network changes; used by tests)."""
+    _dns_cache.clear()
+
+
+def _dns_cache_get(key):
+    entry = _dns_cache.get(key)
+    if entry is None:
+        return None
+    result, ts = entry
+    if time.ticks_diff(time.ticks_ms(), ts) >= _DNS_CACHE_TTL_MS:
+        _dns_cache.pop(key, None)
+        return None
+    return result
 
 
 async def getaddrinfo_async(host, port, proto=0, socktype=None):
@@ -67,12 +93,21 @@ async def getaddrinfo_async(host, port, proto=0, socktype=None):
     if socktype is None:
         socktype = socket.SOCK_STREAM
 
+    # Serve a cached resolution immediately when still fresh -- no worker thread
+    # (and no event-loop yield) needed. Applies on every platform.
+    key = (host, port, proto, socktype)
+    cached = _dns_cache_get(key)
+    if cached is not None:
+        return cached
+
     # On the unix port _thread is marked 'unsafe'; spawning worker threads for
     # DNS on desktop corrupts the heap and crashes the process. Call getaddrinfo
     # directly there (it is reasonably fast and does not block an LVGL task
     # handler on desktop). On ESP32 keep the off-loop worker thread.
     if sys.platform == "linux":
-        return _getaddrinfo(host, port, proto, socktype)
+        result = _getaddrinfo(host, port, proto, socktype)
+        _dns_cache[key] = (result, time.ticks_ms())
+        return result
 
     global _inflight
 
@@ -120,4 +155,6 @@ async def getaddrinfo_async(host, port, proto=0, socktype=None):
     if _result["exc"] is not None:
         raise _result["exc"]
 
+    # Cache only successful results so a later lookup can skip the worker thread.
+    _dns_cache[key] = (_result["value"], time.ticks_ms())
     return _result["value"]

--- a/tests/test_async_dns.py
+++ b/tests/test_async_dns.py
@@ -25,24 +25,23 @@ FAKE_AI = [(2, 1, 0, '', ('93.184.216.34', 80))]
 class TestGetaddrinfoAsync(unittest.TestCase):
 
     def setUp(self):
-        # Off-loop DNS is only used on ESP32; on linux getaddrinfo runs
-        # synchronously so there is no worker thread to test.
-        self._skip = sys.platform == "linux"
-        if self._skip:
-            return
-
         import mpos.net.async_dns as async_dns_mod
         self._async_dns_mod = async_dns_mod
         # Save the module-level _getaddrinfo reference so tearDown can restore it.
         # This variable is a Python-level module attribute and CAN be replaced,
         # unlike the built-in socket.getaddrinfo C attribute.
         self._orig_getaddrinfo = async_dns_mod._getaddrinfo
+        # Start each test with an empty DNS cache so a resolution actually runs
+        # (a cached host would return instantly without spawning a worker).
+        async_dns_mod.clear_dns_cache()
+        # The off-loop worker thread is only used on ESP32; on linux getaddrinfo
+        # runs synchronously, so thread-specific tests are skipped there.
+        self._skip = sys.platform == "linux"
 
     def tearDown(self):
         # Restore original _getaddrinfo to avoid pollution between tests.
-        if self._skip:
-            return
         self._async_dns_mod._getaddrinfo = self._orig_getaddrinfo
+        self._async_dns_mod.clear_dns_cache()
 
     # ------------------------------------------------------------------
 
@@ -103,3 +102,50 @@ class TestGetaddrinfoAsync(unittest.TestCase):
         import asyncio
         raised = asyncio.run(self._run_test_exception())
         self.assertTrue(raised, "OSError from worker thread was not re-raised")
+
+    # ------------------------------------------------------------------
+
+    async def _run_test_cache(self):
+        import asyncio
+        from mpos.net.async_dns import getaddrinfo_async
+        calls = {"n": 0}
+
+        def _counting_getaddrinfo(*a, **kw):
+            calls["n"] += 1
+            return FAKE_AI
+
+        self._async_dns_mod._getaddrinfo = _counting_getaddrinfo
+        r1 = await getaddrinfo_async("cached.example", 80)
+        r2 = await getaddrinfo_async("cached.example", 80)
+        return r1, r2, calls["n"]
+
+    def test_repeat_lookup_hits_cache(self):
+        """A repeated lookup for the same host serves from cache without re-resolving."""
+        import asyncio
+        r1, r2, ncalls = asyncio.run(self._run_test_cache())
+        self.assertEqual(r1, FAKE_AI)
+        self.assertEqual(r2, FAKE_AI)
+        self.assertEqual(ncalls, 1, "second lookup should hit the cache, not re-resolve")
+
+    async def _run_test_error_not_cached(self):
+        import asyncio
+        from mpos.net.async_dns import getaddrinfo_async
+        calls = {"n": 0}
+
+        def _failing(*a, **kw):
+            calls["n"] += 1
+            raise OSError(-2, "Name or service not known")
+
+        self._async_dns_mod._getaddrinfo = _failing
+        for _ in range(2):
+            try:
+                await getaddrinfo_async("bad.invalid", 80)
+            except OSError:
+                pass
+        return calls["n"]
+
+    def test_error_is_not_cached(self):
+        """A failed resolution must not be cached; the next lookup re-resolves."""
+        import asyncio
+        ncalls = asyncio.run(self._run_test_error_not_cached())
+        self.assertEqual(ncalls, 2, "failed lookups must re-resolve, not serve a cached error")


### PR DESCRIPTION
## What

`async_dns.getaddrinfo_async` now caches successful resolutions per `(host, port, proto, socktype)` with a 5-minute TTL, so repeated lookups for the same host reuse the result instead of spawning a resolver worker thread each time.

## Why

`getaddrinfo_async` spawns a `_thread` worker per lookup (correctly, to keep the loop alive during blocking DNS). But the ESP32-S3 thread pool is small, so any workload that resolves the same host repeatedly can exhaust it, after which new lookups fail with `OSError: can't create thread` and downstream requests fail.

This showed up in the wild on a Fri3d badge: streaming an album (a fetch per fragment) alongside a background app that constantly retried unreachable relays drained the pool, and both then hit `can't create thread`. The fetches and the retries were all re-resolving the same handful of hosts every time. Caching the resolution removes those redundant threads entirely, so retries and repeat downloads become pure-async.

## Details

- Cache check runs **before** the `sys.platform == "linux"` branch, so it applies on both desktop and ESP32 (and is exercised by the desktop tests).
- Only **successful** results are cached; failures re-resolve (so a transient error is not sticky).
- `clear_dns_cache()` is exposed for network changes / tests.
- 5-minute TTL keeps entries fresh enough to follow DNS changes.

## Tests

`tests/test_async_dns.py`: `setUp`/`tearDown` clear the cache; two new tests verify a repeated lookup hits the cache (no re-resolve) and that a failed lookup is not cached. All pass on the desktop build (`./tests/unittest.sh tests/test_async_dns.py`).

Follow-up to the off-loop DNS work in `async_dns`.
