### PR TITLE
fix get_ipv4_netmask to get the netmask (not the address)

### DIFF
--- a/internal_filesystem/lib/mpos/net/wifi_service.py
+++ b/internal_filesystem/lib/mpos/net/wifi_service.py
@@ -513,7 +513,7 @@ class WifiService:
 
 
     @staticmethod
-    def _get_ipv4_value(network_module, ap_index, sta_key, desktop_value, label):
+    def _get_ipv4_value(network_module, ap_index, sta_key, desktop_value, label, tuple_index=0):
         if WifiService.wifi_busy:
             return None
 
@@ -528,7 +528,7 @@ class WifiService:
             wlan = WifiService._get_sta_wlan(net)
             value = wlan.ipconfig(sta_key)
             if isinstance(value, tuple):
-                return value[0] if value else None
+                return value[tuple_index] if len(value) > tuple_index else None
             return value
         except Exception as e:
             logger.error("Error retrieving ipv4 %s: %s", label, e)
@@ -552,6 +552,7 @@ class WifiService:
             sta_key="addr4",
             desktop_value="255.255.255.0",
             label="netmask",
+            tuple_index=1, # netmask is the second element in the tuple returned by wlan.ipconfig('addr4')
         )
 
     @staticmethod


### PR DESCRIPTION
## Problem
The **IPv4 Netmask** in the About app showed the same value as **IPv4 address**.

## Reason
As documented in https://docs.micropython.org/en/latest/library/network.html#network.AbstractNIC.ipconfig, addr4 (e.g. 192.168.0.4/24) obtains the current IPv4 address and network mask as (ip, subnet)-tuple.

## Solution
* Add **tuple_index** (defaults to `0`) to the **_get_ipv4_value** method in wifi_service.py.
* Change the **get_ipv4_netmask** method to get the second element from the addr4 tuple (index=1).

## Testing
Compiled and successfully tested on Fri3d Camp 2026 badge hardware.