### PR TITLE
Re-export mpos.lights from the top-level mpos package

### DIFF
--- a/internal_filesystem/lib/mpos/__init__.py
+++ b/internal_filesystem/lib/mpos/__init__.py
@@ -73,6 +73,7 @@ from . import sensor_manager
 from . import camera_manager
 from . import sdcard
 from . import audio
+from . import lights
 
 __all__ = (
     # Core framework
@@ -118,7 +119,7 @@ __all__ = (
     "retry_action_until", "wait_for_focus",
     # Submodules
     "ui", "shared_preferences", "net", "content", "time", "sensor_manager",
-    "camera_manager", "sdcard", "audio",
+    "camera_manager", "sdcard", "audio", "lights",
     # Timezone utilities
     "TimeZone"
 )


### PR DESCRIPTION
Every other framework follows the documented "from mpos import X" import convention (architecture/frameworks/), enforced via re-exports in mpos/__init__.py. mpos.lights (LightsManager) was the one exception -- not in the Available Frameworks list and not re-exported, forcing the submodule import the docs explicitly say to avoid. Even the Fri3d 2026 board's own init code (board/fri3d_2026.py) has to reach for `import mpos.lights as LightsManager` as a result.

Adds it to the same "from . import X" + __all__ pattern already used for ui/net/audio/etc., matching the plain-module submodule-exposure style those already use (lights.py exposes module-level functions, not a class, so this mirrors that rather than the class-based singleton pattern used by AudioManager/SensorManager/etc.).

Closes #196 