### PR TITLE
fix(nostr): exponential reconnect backoff so unreachable relays stop exhausting the thread pool (#191)

### DIFF
--- a/internal_filesystem/lib/uaiowebsocket.py
+++ b/internal_filesystem/lib/uaiowebsocket.py
@@ -54,6 +54,16 @@ class WebSocketConnectionClosedException(WebSocketException):
 class WebSocketTimeoutException(WebSocketException):
     pass
 
+# Reconnect backoff ceiling (seconds): a failing relay must not be retried in a
+# tight loop (each attempt spawns a DNS _thread; the ESP32 pool is tiny) (#191).
+_RECONNECT_MAX_S = 300
+
+def _next_backoff(current, connected_ok, min_s, max_s=_RECONNECT_MAX_S):
+    """Reset to min after a live connection closed, else grow toward max."""
+    if connected_ok:
+        return min_s
+    return min(current * 2, max_s)
+
 # Queue for callback dispatching
 _callback_queue = ucollections.deque((), 100)  # Empty tuple, maxlen=100
 
@@ -289,6 +299,12 @@ class WebSocketApp:
         except Exception as e:
             logger.error("websocket create_task(_process_callbacks_async()) exception: %s", e)
 
+        # Exponential backoff seeded from reconnect_interval. Waiting before
+        # EVERY reconnect (not just after an exception) closes the tight loop
+        # where a relay that accepts then drops the socket returns without
+        # raising; connected_ok resets the delay after a live session so an
+        # unreachable relay backs off instead of hammering the pool (#191).
+        backoff = reconnect_interval or 3
         while self.running:
             _log_debug("Main loop iteration: self.running=True")
             if not _network_available():
@@ -299,19 +315,24 @@ class WebSocketApp:
                     )
                 await asyncio.sleep(reconnect_interval or 3)
                 continue
+            connected_ok = False
             try:
                 await self._connect_and_run() # keep waiting for it, until finished
+                connected_ok = True
             except Exception as e:
                 _log_error(f"_async_main's await self._connect_and_run() for {self.url} got exception: {e}")
                 self.has_errored = True
                 _run_callback(self.on_error, self, e)
-                if reconnect_interval <= 0:
-                    _log_debug("No reconnect configured, breaking loop")
-                    break
-                _log_debug(f"Reconnecting after error in {reconnect_interval}s")
-                await asyncio.sleep(reconnect_interval)
-                if self.on_reconnect:
-                    _run_callback(self.on_reconnect, self)
+            if not self.running:
+                break
+            if reconnect_interval <= 0:
+                _log_debug("No reconnect configured, breaking loop")
+                break
+            backoff = _next_backoff(backoff, connected_ok, reconnect_interval)
+            _log_debug(f"Reconnecting to {self.url} in {backoff}s")
+            await asyncio.sleep(backoff)
+            if self.on_reconnect:
+                _run_callback(self.on_reconnect, self)
 
         # Cleanup
         _log_debug("Initiating cleanup")

--- a/tests/test_uaiowebsocket_backoff.py
+++ b/tests/test_uaiowebsocket_backoff.py
@@ -1,0 +1,55 @@
+"""test_uaiowebsocket_backoff.py - Unit tests for the reconnect backoff helper.
+
+Verifies uaiowebsocket._next_backoff (the pure function driving the relay
+reconnect loop) grows geometrically toward the cap while a relay stays
+unreachable, and snaps back to the minimum once a live connection closes.
+
+Network-free: only imports the pure helper, no sockets or event loop.
+
+Usage:
+    Desktop: ./tests/unittest.sh tests/test_uaiowebsocket_backoff.py
+"""
+
+import sys
+import unittest
+
+sys.path.insert(0, '../internal_filesystem/lib')
+
+from uaiowebsocket import _next_backoff, _RECONNECT_MAX_S
+
+MIN_S = 3
+
+
+class TestReconnectBackoff(unittest.TestCase):
+
+    def test_first_failure_doubles_min(self):
+        """A failure from the seed interval doubles it, staying below the cap."""
+        self.assertEqual(_next_backoff(MIN_S, False, MIN_S), 6)
+
+    def test_geometric_growth_to_cap(self):
+        """Repeated failures double the delay until clamped at the max."""
+        expected = [6, 12, 24, 48, 96, 192, 300, 300, 300]
+        delay = MIN_S
+        seen = []
+        for _ in range(len(expected)):
+            delay = _next_backoff(delay, False, MIN_S)
+            seen.append(delay)
+        self.assertEqual(seen, expected)
+
+    def test_never_exceeds_max(self):
+        """A delay already at the cap cannot grow past it."""
+        self.assertEqual(_next_backoff(_RECONNECT_MAX_S, False, MIN_S), _RECONNECT_MAX_S)
+
+    def test_reset_on_live_connection(self):
+        """A session that actually connected resets the delay to the seed min."""
+        self.assertEqual(_next_backoff(_RECONNECT_MAX_S, True, MIN_S), MIN_S)
+        self.assertEqual(_next_backoff(192, True, MIN_S), MIN_S)
+
+    def test_seed_min_is_honored(self):
+        """A custom (larger) reconnect interval is used as the floor on reset."""
+        self.assertEqual(_next_backoff(48, True, 5), 5)
+        self.assertEqual(_next_backoff(5, False, 5), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix #2 for #191. Builds on the reconnect rework already merged to `main`.

## What #191 asked for
The Nostr relay service retried unreachable relays with no backoff. Each attempt resolves DNS and spawns a `_thread`, and the ESP32-S3 pool is tiny, so hammering a dead relay starved other apps' networking (this is what broke audio playback in The Free Lantern Player). The DNS cache (#189) was fix #1; this is fix #2.

## What was still wrong on `main`
`main` already normalises `reconnect_interval` and gates on `_network_available()`, which handles the "Wi-Fi fully down" case. But two gaps remained when Wi-Fi is up and a specific relay is unreachable or flapping:

1. **Clean-close tight loop.** When a relay accepts the socket then drops it, `_connect_and_run()` returns without raising, so the `except` branch (with its `sleep`) never runs. The `while self.running:` loop reconnects with **zero delay** and hammers.
2. **No backoff.** The exception path waits a fixed `reconnect_interval` (3s) forever, so a permanently dead relay keeps retrying every 3s.

## The fix
Exponential backoff in `_async_main`, seeded from `reconnect_interval`:

- Wait before **every** reconnect (not just after an exception), which closes the clean-close zero-delay loop.
- `connected_ok` tracks whether the just-ended session was actually live: reset the delay to the seed interval after a live close, otherwise double it toward a 300s ceiling. An unreachable relay backs off (3s -> 6 -> 12 -> ... -> 300) instead of spinning; a healthy relay that blips recovers fast.
- No relay is abandoned, so one that recovers reconnects on its own.

The backoff math is a pure helper (`_next_backoff`) so it is unit-testable without a network. `reconnect_interval <= 0` still disables reconnect, and `_network_available()` gating is unchanged.

Scope is exactly the Nostr relay service: `WebSocketApp` is only used by `nostr/relay.py` (nostr app + NWC both go through it).

## Testing
- New `tests/test_uaiowebsocket_backoff.py`: 5/5 pass on the desktop build (`./tests/unittest.sh tests/test_uaiowebsocket_backoff.py`), network-free. Covers geometric growth, the 300s cap, reset-on-live-connection, and a custom seed interval as the floor.
- `mpy-cross` compiles clean; ASCII-only, MicroPython-compatible.
