### PR TITLE
Add web and desktop audio support

### DIFF
--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -73,7 +73,7 @@ jobs:
           cp lvgl_micropython/build/lvgl_micropy_unix lvgl_micropython/build/MicroPythonOS_arm64_linux_${{ steps.version.outputs.OS_VERSION }}.elf
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_arm64_linux_${{ steps.version.outputs.OS_VERSION }}.elf
           path: lvgl_micropython/build/MicroPythonOS_arm64_linux_${{ steps.version.outputs.OS_VERSION }}.elf

--- a/.github/workflows/linux-specials.yml
+++ b/.github/workflows/linux-specials.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -74,14 +74,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC/MicroPythonOS_esp32-small_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32-small_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32-small_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32-small_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC/MicroPythonOS_esp32-small_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -94,14 +94,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3-unphone_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3-unphone_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32s3-unphone_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3-unphone_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3-unphone_${{ steps.version.outputs.OS_VERSION }}.ota

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -74,14 +74,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -94,14 +94,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -113,7 +113,7 @@ jobs:
           cp lvgl_micropython/build/lvgl_micropy_unix lvgl_micropython/build/MicroPythonOS_x64_linux_${{ steps.version.outputs.OS_VERSION }}.elf
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_x64_linux_${{ steps.version.outputs.OS_VERSION }}.elf
           path: lvgl_micropython/build/MicroPythonOS_x64_linux_${{ steps.version.outputs.OS_VERSION }}.elf

--- a/.github/workflows/macos-intel.yml
+++ b/.github/workflows/macos-intel.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -43,14 +43,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -63,14 +63,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -82,7 +82,7 @@ jobs:
           cp lvgl_micropython/build/lvgl_micropy_macOS lvgl_micropython/build/MicroPythonOS_intel_macOS_${{ steps.version.outputs.OS_VERSION }}.bin
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_intel_macOS_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_intel_macOS_${{ steps.version.outputs.OS_VERSION }}.bin

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -51,14 +51,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC-SPIRAM/MicroPythonOS_esp32_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -71,14 +71,14 @@ jobs:
           mv lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/micropython.bin lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.bin
           retention-days: 7
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
           path: lvgl_micropython/lib/micropython/ports/esp32/build-ESP32_GENERIC_S3-SPIRAM_OCT/MicroPythonOS_esp32s3_${{ steps.version.outputs.OS_VERSION }}.ota
@@ -90,7 +90,7 @@ jobs:
           cp lvgl_micropython/build/lvgl_micropy_macOS lvgl_micropython/build/MicroPythonOS_arm64_macOS_${{ steps.version.outputs.OS_VERSION }}.bin
 
       - name: Upload built binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_arm64_macOS_${{ steps.version.outputs.OS_VERSION }}.bin
           path: lvgl_micropython/build/MicroPythonOS_arm64_macOS_${{ steps.version.outputs.OS_VERSION }}.bin

--- a/.github/workflows/web-pages.yml
+++ b/.github/workflows/web-pages.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Emscripten SDK
         # Puts emcc/em++/emar on PATH so build_mpos.sh skips its in-tree
         # emsdk lookup. Bump the version if the build needs a newer toolchain.
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@v16
         with:
           version: 6.0.0
 
@@ -65,7 +65,7 @@ jobs:
           node tests/web_bridge_smoke.mjs web
 
       - name: Upload built web export as a regular artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MicroPythonOS_web_${{ steps.version.outputs.OS_VERSION }}.zip
           path: web/

--- a/internal_filesystem/lib/mpos/audio/audiomanager.py
+++ b/internal_filesystem/lib/mpos/audio/audiomanager.py
@@ -5,6 +5,7 @@ import _thread
 import logging
 import math
 import os
+import sys
 
 from ..shared_preferences import SharedPreferences
 from ..task_manager import TaskManager
@@ -726,38 +727,90 @@ class Player:
             else:
                 self._play_wav()
         finally:
-            if self._buzzer:
-                try:
-                    self._buzzer.deinit()
-                except Exception:
-                    pass
-            self._manager._session_finished(self)
+            if not (self._stream and getattr(self._stream, "runs_async", False)):
+                if self._buzzer:
+                    try:
+                        self._buzzer.deinit()
+                    except Exception:
+                        pass
+                self._manager._session_finished(self)
 
     def _play_rtttl(self):
-        from mpos.audio.stream_rtttl import RTTTLStream
+        from mpos.audio.stream_rtttl import DesktopRTTTLStream, RTTTLStream, WebRTTTLStream
+
+        is_web = False
+        if sys.platform != "esp32":
+            try:
+                __import__("_webio")
+                is_web = True
+            except ImportError:
+                pass
+
+        if sys.platform != "esp32" and not is_web:
+            self._stream = DesktopRTTTLStream(
+                rtttl_string=self.rtttl,
+                stream_type=self.stream_type,
+                volume=self.volume if self.volume is not None else self._manager._volume,
+                on_complete=self.on_complete,
+            )
+            self._stream.set_repeat(self._repeat_count)
+            self._stream.play()
+            return
+
         from machine import Pin, PWM
 
         self._buzzer = PWM(Pin(self.output.buzzer_pin, Pin.OUT))
         self._buzzer.duty_u16(0)
 
-        self._stream = RTTTLStream(
+        on_complete = self.on_complete
+        stream_class = RTTTLStream
+        if is_web:
+            stream_class = WebRTTTLStream
+
+            def on_complete(message):
+                try:
+                    if self.on_complete:
+                        self.on_complete(message)
+                finally:
+                    if self._buzzer:
+                        try:
+                            self._buzzer.deinit()
+                        except Exception:
+                            pass
+                    self._manager._session_finished(self)
+
+        self._stream = stream_class(
             rtttl_string=self.rtttl,
             stream_type=self.stream_type,
             volume=self.volume if self.volume is not None else self._manager._volume,
             buzzer_instance=self._buzzer,
-            on_complete=self.on_complete,
+            on_complete=on_complete,
         )
+        self._stream.set_repeat(self._repeat_count)
         self._stream.play()
 
     def _play_wav(self):
         from mpos.audio.stream_wav import WAVStream
+
+        on_complete = self.on_complete
+        try:
+            __import__("_webio")
+
+            def on_complete(message):
+                try:
+                    if self.on_complete:
+                        self.on_complete(message)
+                finally:
+                    self._manager._session_finished(self)
+        except ImportError:
+            pass
 
         self._stream = WAVStream(
             file_path=self.file_path,
             stream_type=self.stream_type,
             volume=self.volume if self.volume is not None else self._manager._volume,
             i2s_pins=self.output.i2s_pins,
-            on_complete=self.on_complete,
+            on_complete=on_complete,
             requested_sample_rate=self.sample_rate,
             on_open=getattr(self.output, "on_open", None),
             on_close=getattr(self.output, "on_close", None),

--- a/internal_filesystem/lib/mpos/audio/stream_rtttl.py
+++ b/internal_filesystem/lib/mpos/audio/stream_rtttl.py
@@ -2,8 +2,10 @@
 # Ring Tone Text Transfer Language parser and player
 # Uses synchronous playback in a separate thread for non-blocking operation
 
+import asyncio
 import logging
 import math
+import os
 import time
 
 logger = logging.getLogger(__name__)
@@ -265,3 +267,162 @@ class RTTTLStream:
         if count < 0:
             count = 0
         self._repeat_count = count
+
+
+class WebRTTTLStream(RTTTLStream):
+    runs_async = True
+
+    @staticmethod
+    def _duty_for_volume(volume):
+        if volume <= 0:
+            return 0
+        volume = min(100, volume)
+        divider = 10
+        return int(
+            ((math.exp(volume / divider) - math.exp(0.1)) /
+             (math.exp(10) - math.exp(0.1)) * (32768 - 4)) + 4
+        )
+
+    async def _play_async(self):
+        try:
+            iteration = 0
+            while self._keep_running and iteration < self._repeat_count:
+                iteration += 1
+                self.tune_idx = 0
+                for frequency, duration_ms in self._notes():
+                    if not self._keep_running:
+                        break
+                    duty = self._duty_for_volume(self.volume)
+                    if frequency > 0:
+                        self.buzzer.freq(int(frequency))
+                        self.buzzer.duty_u16(duty)
+                    await asyncio.sleep_ms(int(duration_ms * 0.9))
+                    self.buzzer.duty_u16(0)
+                    await asyncio.sleep_ms(int(duration_ms * 0.1))
+            if self.on_complete:
+                self.on_complete("Finished: %s" % self.name)
+        except Exception as e:
+            logger.error("Error: %s", e)
+            if self.on_complete:
+                self.on_complete("Error: %s" % e)
+        finally:
+            try:
+                self.buzzer.duty_u16(0)
+            except RuntimeError:
+                pass
+            self._is_playing = False
+
+    def play(self):
+        self._is_playing = True
+        asyncio.get_event_loop().create_task(self._play_async())
+
+
+class DesktopRTTTLStream(RTTTLStream):
+    def __init__(self, rtttl_string, stream_type, volume, on_complete):
+        super().__init__(rtttl_string, stream_type, volume, None, on_complete)
+        self._wav_stream = None
+        self._temp_path = "/tmp/mpos_rtttl_%d.wav" % id(self)
+
+    @staticmethod
+    def _write_samples(file, frequency, sample_count, sample_rate):
+        chunk_samples = 1024
+        phase = 0.0
+        remaining = sample_count
+        while remaining > 0:
+            count = min(chunk_samples, remaining)
+            data = bytearray(count * 2)
+            for index in range(count):
+                value = 12000 if phase < sample_rate / 2 else -12000
+                value &= 0xFFFF
+                data[index * 2] = value & 0xFF
+                data[index * 2 + 1] = value >> 8
+                phase += frequency
+                if phase >= sample_rate:
+                    phase -= sample_rate
+            file.write(data)
+            remaining -= count
+
+    @staticmethod
+    def _write_silence(file, sample_count):
+        chunk = bytes(2048)
+        remaining = sample_count * 2
+        while remaining > 0:
+            count = min(len(chunk), remaining)
+            file.write(chunk[:count])
+            remaining -= count
+
+    def _render(self):
+        sample_rate = 22050
+        data_size = 0
+        with open(self._temp_path, "wb") as file:
+            file.write(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+            file.write((16).to_bytes(4, "little"))
+            file.write((1).to_bytes(2, "little"))
+            file.write((1).to_bytes(2, "little"))
+            file.write(sample_rate.to_bytes(4, "little"))
+            file.write((sample_rate * 2).to_bytes(4, "little"))
+            file.write((2).to_bytes(2, "little"))
+            file.write((16).to_bytes(2, "little"))
+            file.write(b"data\x00\x00\x00\x00")
+
+            iteration = 0
+            while self._keep_running and iteration < self._repeat_count:
+                iteration += 1
+                self.tune_idx = 0
+                for frequency, duration_ms in self._notes():
+                    if not self._keep_running:
+                        break
+                    tone_samples = int(sample_rate * duration_ms * 0.9 / 1000)
+                    silence_samples = int(sample_rate * duration_ms * 0.1 / 1000)
+                    if frequency > 0:
+                        self._write_samples(file, frequency, tone_samples, sample_rate)
+                    else:
+                        self._write_silence(file, tone_samples)
+                    self._write_silence(file, silence_samples)
+                    data_size += (tone_samples + silence_samples) * 2
+
+            file.seek(4)
+            file.write((data_size + 36).to_bytes(4, "little"))
+            file.seek(40)
+            file.write(data_size.to_bytes(4, "little"))
+
+    def play(self):
+        from mpos.audio.stream_wav import WAVStream
+
+        self._is_playing = True
+        try:
+            self._render()
+            if not self._keep_running:
+                if self.on_complete:
+                    self.on_complete("Finished: %s" % self.name)
+                return
+            self._wav_stream = WAVStream(
+                file_path=self._temp_path,
+                stream_type=self.stream_type,
+                volume=self.volume,
+                i2s_pins={"ws": 0, "sd": 0},
+                on_complete=None,
+            )
+            self._wav_stream.play()
+            if self.on_complete:
+                self.on_complete("Finished: %s" % self.name)
+        except Exception as e:
+            logger.error("Error: %s", e)
+            if self.on_complete:
+                self.on_complete("Error: %s" % e)
+        finally:
+            self._is_playing = False
+            try:
+                os.remove(self._temp_path)
+            except OSError:
+                pass
+
+    def stop(self):
+        self._keep_running = False
+        if self._wav_stream:
+            self._wav_stream.stop()
+
+    def set_volume(self, vol):
+        self.volume = vol
+        if self._wav_stream:
+            self._wav_stream.set_volume(vol)

--- a/internal_filesystem/lib/mpos/audio/stream_wav.py
+++ b/internal_filesystem/lib/mpos/audio/stream_wav.py
@@ -2,6 +2,7 @@
 # Supports 8/16/24/32-bit PCM, mono+stereo, auto-upsampling.
 # Uses synchronous playback in a separate thread for non-blocking operation.
 
+import asyncio
 import logging
 import machine
 import micropython
@@ -127,6 +128,8 @@ class WAVStream:
         self._is_playing = False
         self._i2s = None
         self._mck_pwm = None
+        self._web_audio = False
+        self.runs_async = False
         self._progress_samples = 0
         self._total_samples = 0
         self._duration_ms = None
@@ -143,6 +146,13 @@ class WAVStream:
     def stop(self):
         """Stop playback."""
         self._keep_running = False
+        if self._web_audio:
+            try:
+                import _webio
+
+                _webio.audio_stop()
+            except ImportError:
+                pass
 
     def get_progress_percent(self):
         if self._total_samples <= 0:
@@ -390,6 +400,35 @@ class WAVStream:
             return 0
         return WAVStream._VOLUME_TO_SHIFT[volume]
 
+    async def _monitor_web_audio(self, webio):
+        start_ticks = time.ticks_ms()
+        try:
+            while self._keep_running:
+                await asyncio.sleep_ms(100)
+                elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
+                if self._playback_rate:
+                    self._progress_samples = min(
+                        int(elapsed_ms / 1000.0 * self._playback_rate),
+                        self._total_samples
+                    )
+                if elapsed_ms >= (self._duration_ms or 0):
+                    break
+            if not self._keep_running:
+                webio.audio_stop()
+            if self.on_complete:
+                self.on_complete("Finished: %s" % self.file_path)
+        except Exception as e:
+            logger.error("Error: %s", e)
+            if self.on_complete:
+                self.on_complete("Error: %s" % e)
+        finally:
+            self._is_playing = False
+            if self.on_close:
+                try:
+                    self.on_close()
+                except Exception as e:
+                    logger.error("on_close failed: %s", e)
+
     # ----------------------------------------------------------------------
     #  Main playback routine
     # ----------------------------------------------------------------------
@@ -440,65 +479,78 @@ class WAVStream:
 
                 # Desktop (non-ESP32) audio playback branch
                 if sys.platform != "esp32":
-                    player = _detect_desktop_player()
-                    quoted = _shell_quote(self.file_path)
+                    webio = None
+                    try:
+                        import _webio
 
-                    if player is None:
-                        logger.warning("Desktop audio: no player found (afplay/ffplay/aplay/paplay); simulating timing")
-                        elapsed_ms = 0
-                        while self._keep_running:
-                            if self._duration_ms is None:
-                                break
-                            time.sleep_ms(100)
-                            elapsed_ms += 100
-                            if self._playback_rate:
-                                self._progress_samples = min(
-                                    int(elapsed_ms / 1000.0 * self._playback_rate),
-                                    self._total_samples
-                                )
-                            if elapsed_ms >= self._duration_ms:
-                                break
+                        webio = _webio
+                    except ImportError:
+                        pass
+
+                    if webio:
+                        self._web_audio = bool(webio.audio_play(self.file_path, self.volume))
+                        self.runs_async = True
+                        asyncio.get_event_loop().create_task(self._monitor_web_audio(webio))
                     else:
-                        # Record the backgrounded player's PID (shell $!) so we can
-                        # stop it precisely by PID instead of `pkill -f <path>`.
-                        pid_file = "/tmp/mpos_audio_%d.pid" % id(self)
-                        qpid = _shell_quote(pid_file)
-                        if player == "afplay":
-                            cmd = "afplay -v %.2f %s >/dev/null 2>&1 & echo $! > %s" % (
-                                max(0.0, min(1.0, self.volume / 100.0)),
-                                quoted,
-                                qpid
-                            )
-                        elif player == "ffplay":
-                            cmd = "ffplay -nodisp -autoexit -loglevel quiet -volume %d %s >/dev/null 2>&1 & echo $! > %s" % (
-                                self.volume,
-                                quoted,
-                                qpid
-                            )
-                        elif player == "aplay":
-                            cmd = "aplay -q %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
+                        player = _detect_desktop_player()
+                        quoted = _shell_quote(self.file_path)
+
+                        if player is None:
+                            logger.warning("Desktop audio: no player found (afplay/ffplay/aplay/paplay); simulating timing")
+                            elapsed_ms = 0
+                            while self._keep_running:
+                                if self._duration_ms is None:
+                                    break
+                                time.sleep_ms(100)
+                                elapsed_ms += 100
+                                if self._playback_rate:
+                                    self._progress_samples = min(
+                                        int(elapsed_ms / 1000.0 * self._playback_rate),
+                                        self._total_samples
+                                    )
+                                if elapsed_ms >= self._duration_ms:
+                                    break
                         else:
-                            cmd = "paplay %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
-
-                        os.system(cmd)
-
-                        start_ticks = time.ticks_ms()
-                        while self._keep_running:
-                            time.sleep_ms(100)
-                            elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
-                            if self._playback_rate:
-                                self._progress_samples = min(
-                                    int(elapsed_ms / 1000.0 * self._playback_rate),
-                                    self._total_samples
+                            # Record the backgrounded player's PID (shell $!) so we can
+                            # stop it precisely by PID instead of `pkill -f <path>`.
+                            pid_file = "/tmp/mpos_audio_%d.pid" % id(self)
+                            qpid = _shell_quote(pid_file)
+                            if player == "afplay":
+                                cmd = "afplay -v %.2f %s >/dev/null 2>&1 & echo $! > %s" % (
+                                    max(0.0, min(1.0, self.volume / 100.0)),
+                                    quoted,
+                                    qpid
                                 )
-                            if elapsed_ms >= (self._duration_ms or 0):
-                                break
+                            elif player == "ffplay":
+                                cmd = "ffplay -nodisp -autoexit -loglevel quiet -volume %d %s >/dev/null 2>&1 & echo $! > %s" % (
+                                    self.volume,
+                                    quoted,
+                                    qpid
+                                )
+                            elif player == "aplay":
+                                cmd = "aplay -q %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
+                            else:
+                                cmd = "paplay %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
 
-                        # Kill the player by its real PID on explicit stop; on natural
-                        # completion it has already exited, so just clean up the pid file.
-                        _stop_desktop_player(pid_file, not self._keep_running)
+                            os.system(cmd)
 
-                    if self.on_complete:
+                            start_ticks = time.ticks_ms()
+                            while self._keep_running:
+                                time.sleep_ms(100)
+                                elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
+                                if self._playback_rate:
+                                    self._progress_samples = min(
+                                        int(elapsed_ms / 1000.0 * self._playback_rate),
+                                        self._total_samples
+                                    )
+                                if elapsed_ms >= (self._duration_ms or 0):
+                                    break
+
+                            # Kill the player by its real PID on explicit stop; on natural
+                            # completion it has already exited, so just clean up the pid file.
+                            _stop_desktop_player(pid_file, not self._keep_running)
+
+                    if not webio and self.on_complete:
                         self.on_complete("Finished: %s" % self.file_path)
                     return
 
@@ -680,22 +732,23 @@ class WAVStream:
                 self.on_complete(f"Error: {e}")
 
         finally:
-            self._is_playing = False
-            if self.on_close:
-                try:
-                    self.on_close()
-                except Exception as e:
-                    logger.error("on_close failed: %s", e)
-            if self._i2s:
-                if __debug__: logger.debug("Done playing, doing i2s deinit")
-                self._i2s.deinit() # disabling this does not fix the "play just once" issue
-                self._i2s = None
-            if self._mck_pwm:
-                try:
-                    if __debug__: logger.debug("Done playing, stopping MCLK PWM")
-                    self._mck_pwm.deinit()
-                finally:
-                    self._mck_pwm = None
+            if not self.runs_async:
+                self._is_playing = False
+                if self.on_close:
+                    try:
+                        self.on_close()
+                    except Exception as e:
+                        logger.error("on_close failed: %s", e)
+                if self._i2s:
+                    if __debug__: logger.debug("Done playing, doing i2s deinit")
+                    self._i2s.deinit() # disabling this does not fix the "play just once" issue
+                    self._i2s = None
+                if self._mck_pwm:
+                    try:
+                        if __debug__: logger.debug("Done playing, stopping MCLK PWM")
+                        self._mck_pwm.deinit()
+                    finally:
+                        self._mck_pwm = None
 
     def set_repeat(self, count):
         """Set total number of times to play the file."""
@@ -709,3 +762,10 @@ class WAVStream:
 
     def set_volume(self, vol):
         self.volume = vol
+        if self._web_audio:
+            try:
+                import _webio
+
+                _webio.audio_volume(vol)
+            except ImportError:
+                pass

--- a/internal_filesystem/lib/mpos/board/linux.py
+++ b/internal_filesystem/lib/mpos/board/linux.py
@@ -125,6 +125,7 @@ input_i2s_pins = {
 }
 
 AudioManager.add(AudioManager.Output("speaker", "i2s", i2s_pins=output_i2s_pins))
+AudioManager.add(AudioManager.Output("buzzer", "buzzer", buzzer_pin=-1))
 AudioManager.add(AudioManager.Input("mic", "i2s", i2s_pins=input_i2s_pins))
 
 # === LED HARDWARE ===

--- a/scripts/web_port/ext_mod/_webio/webio.c
+++ b/scripts/web_port/ext_mod/_webio/webio.c
@@ -53,6 +53,257 @@ EM_JS(int, webio_js_joy, (int axis), {
     return (axis ? H.joy_y : H.joy_x) | 0;
 });
 
+EM_JS(void, webio_js_audio_init, (void), {
+    var H = Module.__webio || (Module.__webio = {});
+    if (H.audio) return;
+    var AudioContext = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContext) return;
+    var A = H.audio = {
+        context: new AudioContext(),
+        oscillator: null,
+        toneGain: null,
+        source: null,
+        sourceGain: null,
+        generation: 0
+    };
+    var unlock = function() {
+        if (A.context.state === "suspended") {
+            A.context.resume().catch(function() {});
+        }
+    };
+    document.addEventListener("pointerdown", unlock, true);
+    document.addEventListener("keydown", unlock, true);
+    document.addEventListener("touchstart", unlock, true);
+});
+
+EM_JS(void, webio_js_tone, (int frequency, int duty), {
+    var H = Module.__webio;
+    if (!H || !H.audio) return;
+    var A = H.audio;
+    if (!A.oscillator) {
+        A.oscillator = A.context.createOscillator();
+        A.oscillator.type = "square";
+        A.toneGain = A.context.createGain();
+        A.toneGain.gain.value = 0;
+        A.oscillator.connect(A.toneGain);
+        A.toneGain.connect(A.context.destination);
+        A.oscillator.start();
+    }
+    var now = A.context.currentTime;
+    A.oscillator.frequency.setValueAtTime(Math.max(1, frequency), now);
+    A.toneGain.gain.setValueAtTime(frequency > 0 ? Math.min(0.2, duty / 163840.0) : 0, now);
+});
+
+EM_JS(void, webio_js_tone_stop, (void), {
+    var H = Module.__webio;
+    if (!H || !H.audio || !H.audio.oscillator) return;
+    var A = H.audio;
+    try { A.oscillator.stop(); } catch (e) {}
+    A.oscillator.disconnect();
+    A.toneGain.disconnect();
+    A.oscillator = null;
+    A.toneGain = null;
+});
+
+EM_JS(int, webio_js_audio_play, (const char *path, int volume), {
+    var H = Module.__webio;
+    if (!H || !H.audio || H.audio.context.state !== "running") return 0;
+    var A = H.audio;
+    var generation = ++A.generation;
+    if (A.source) {
+        try { A.source.stop(); } catch (e) {}
+        A.source = null;
+    }
+    var bytes;
+    try {
+        bytes = FS.readFile(UTF8ToString(path));
+    } catch (e) {
+        console.error("Web audio read failed:", e);
+        return 0;
+    }
+
+    function startBuffer(buffer) {
+        if (generation !== A.generation) return;
+        var source = A.context.createBufferSource();
+        var gain = A.context.createGain();
+        gain.gain.value = Math.max(0, Math.min(1, volume / 100));
+        source.buffer = buffer;
+        source.connect(gain);
+        gain.connect(A.context.destination);
+        source.onended = function() {
+            if (A.source === source) {
+                A.source = null;
+                A.sourceGain = null;
+            }
+        };
+        A.source = source;
+        A.sourceGain = gain;
+        source.start();
+    }
+
+    function decodeWav(data) {
+        var view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+        function tag(offset) {
+            return String.fromCharCode(
+                view.getUint8(offset), view.getUint8(offset + 1),
+                view.getUint8(offset + 2), view.getUint8(offset + 3)
+            );
+        }
+        if (tag(0) !== "RIFF" || tag(8) !== "WAVE") throw new Error("not a WAV file");
+        var format = 0;
+        var channels = 0;
+        var sampleRate = 0;
+        var blockAlign = 0;
+        var bits = 0;
+        var dataOffset = 0;
+        var dataSize = 0;
+        var factSamples = 0;
+        var pos = 12;
+        while (pos + 8 <= view.byteLength) {
+            var id = tag(pos);
+            var size = view.getUint32(pos + 4, true);
+            var start = pos + 8;
+            if (id === "fmt " && size >= 16) {
+                format = view.getUint16(start, true);
+                channels = view.getUint16(start + 2, true);
+                sampleRate = view.getUint32(start + 4, true);
+                blockAlign = view.getUint16(start + 12, true);
+                bits = view.getUint16(start + 14, true);
+                if (format === 0xfffe && size >= 26) format = view.getUint16(start + 24, true);
+            } else if (id === "fact" && size >= 4) {
+                factSamples = view.getUint32(start, true);
+            } else if (id === "data") {
+                dataOffset = start;
+                dataSize = Math.min(size, view.byteLength - start);
+            }
+            pos = start + size + (size & 1);
+        }
+        if (!channels || !sampleRate || !dataOffset || !dataSize) throw new Error("invalid WAV header");
+
+        if (format === 1) {
+            var bytesPerSample = bits >> 3;
+            var frames = Math.floor(dataSize / (channels * bytesPerSample));
+            var pcmBuffer = A.context.createBuffer(channels, frames, sampleRate);
+            var pcmChannels = [];
+            for (var c = 0; c < channels; c++) pcmChannels.push(pcmBuffer.getChannelData(c));
+            var offset = dataOffset;
+            for (var frame = 0; frame < frames; frame++) {
+                for (var channel = 0; channel < channels; channel++) {
+                    var sample;
+                    if (bits === 8) {
+                        sample = (view.getUint8(offset) - 128) / 128;
+                    } else if (bits === 16) {
+                        sample = view.getInt16(offset, true) / 32768;
+                    } else if (bits === 24) {
+                        var raw = view.getUint8(offset) | (view.getUint8(offset + 1) << 8) |
+                            (view.getUint8(offset + 2) << 16);
+                        if (raw & 0x800000) raw |= 0xff000000;
+                        sample = raw / 8388608;
+                    } else if (bits === 32) {
+                        sample = view.getInt32(offset, true) / 2147483648;
+                    } else {
+                        throw new Error("unsupported PCM depth " + bits);
+                    }
+                    pcmChannels[channel][frame] = sample;
+                    offset += bytesPerSample;
+                }
+            }
+            return pcmBuffer;
+        }
+
+        if (format === 0x11) {
+            var steps = [
+                7,8,9,10,11,12,13,14,16,17,19,21,23,25,28,31,34,37,41,45,50,55,60,66,
+                73,80,88,97,107,118,130,143,157,173,190,209,230,253,279,307,337,371,408,
+                449,494,544,598,658,724,796,876,963,1060,1166,1282,1411,1552,1707,1878,
+                2066,2272,2499,2749,3024,3327,3660,4026,4428,4871,5358,5894,6484,7132,
+                7845,8630,9493,10442,11487,12635,13900,15289,16818,18500,20350,22385,
+                24623,27086,29794,32767
+            ];
+            var indexes = [-1,-1,-1,-1,2,4,6,8,-1,-1,-1,-1,2,4,6,8];
+            var samplesPerBlock = 1 + Math.floor((blockAlign - 4 * channels) * 2 / channels);
+            var blockCount = Math.floor(dataSize / blockAlign);
+            var totalFrames = factSamples || blockCount * samplesPerBlock;
+            var adpcmBuffer = A.context.createBuffer(channels, totalFrames, sampleRate);
+            var adpcmChannels = [];
+            for (var ac = 0; ac < channels; ac++) adpcmChannels.push(adpcmBuffer.getChannelData(ac));
+            var blockOffset = dataOffset;
+            var frameBase = 0;
+            for (var block = 0; block < blockCount && frameBase < totalFrames; block++) {
+                var predictors = [];
+                var stepIndexes = [];
+                var writePositions = [];
+                for (var headerChannel = 0; headerChannel < channels; headerChannel++) {
+                    var header = blockOffset + headerChannel * 4;
+                    predictors[headerChannel] = view.getInt16(header, true);
+                    stepIndexes[headerChannel] = Math.max(0, Math.min(88, view.getUint8(header + 2)));
+                    adpcmChannels[headerChannel][frameBase] = predictors[headerChannel] / 32768;
+                    writePositions[headerChannel] = frameBase + 1;
+                }
+                var encodedPos = blockOffset + 4 * channels;
+                var blockEnd = blockOffset + blockAlign;
+                while (encodedPos + 4 * channels <= blockEnd) {
+                    for (var encodedChannel = 0; encodedChannel < channels; encodedChannel++) {
+                        for (var byteIndex = 0; byteIndex < 4; byteIndex++) {
+                            var encodedByte = view.getUint8(encodedPos++);
+                            for (var half = 0; half < 2; half++) {
+                                var nibble = half ? encodedByte >> 4 : encodedByte & 15;
+                                var step = steps[stepIndexes[encodedChannel]];
+                                var diff = (((nibble & 7) * 2 + 1) * step) >> 3;
+                                predictors[encodedChannel] += (nibble & 8) ? -diff : diff;
+                                predictors[encodedChannel] = Math.max(-32768, Math.min(32767, predictors[encodedChannel]));
+                                stepIndexes[encodedChannel] = Math.max(
+                                    0, Math.min(88, stepIndexes[encodedChannel] + indexes[nibble])
+                                );
+                                if (writePositions[encodedChannel] < totalFrames) {
+                                    adpcmChannels[encodedChannel][writePositions[encodedChannel]++] =
+                                        predictors[encodedChannel] / 32768;
+                                }
+                            }
+                        }
+                    }
+                }
+                frameBase += samplesPerBlock;
+                blockOffset += blockAlign;
+            }
+            return adpcmBuffer;
+        }
+
+        throw new Error("unsupported WAV format " + format);
+    }
+
+    try {
+        startBuffer(decodeWav(bytes));
+    } catch (wavError) {
+        var encoded = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+        A.context.decodeAudioData(encoded).then(startBuffer).catch(function(e) {
+            console.error("Web audio decode failed:", wavError, e);
+        });
+    }
+    return 1;
+});
+
+EM_JS(void, webio_js_audio_stop, (void), {
+    var H = Module.__webio;
+    if (!H || !H.audio) return;
+    var A = H.audio;
+    ++A.generation;
+    if (A.source) {
+        try { A.source.stop(); } catch (e) {}
+        A.source = null;
+        A.sourceGain = null;
+    }
+});
+
+EM_JS(void, webio_js_audio_volume, (int volume), {
+    var H = Module.__webio;
+    if (!H || !H.audio || !H.audio.sourceGain) return;
+    H.audio.sourceGain.gain.setValueAtTime(
+        Math.max(0, Math.min(1, volume / 100)),
+        H.audio.context.currentTime
+    );
+});
+
 // ---------------------------------------------------------------------------
 // MicroPython bindings
 // ---------------------------------------------------------------------------
@@ -60,6 +311,7 @@ EM_JS(int, webio_js_joy, (int axis), {
 // init() -> None  (ensure Module.__webio.{buttons,joy_x,joy_y,onLeds} exist)
 static mp_obj_t webio_init(void) {
     webio_js_init();
+    webio_js_audio_init();
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(webio_init_obj, webio_init);
@@ -91,12 +343,50 @@ static mp_obj_t webio_joystick(void) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(webio_joystick_obj, webio_joystick);
 
+static mp_obj_t webio_tone(mp_obj_t frequency_in, mp_obj_t duty_in) {
+    webio_js_audio_init();
+    webio_js_tone(mp_obj_get_int(frequency_in), mp_obj_get_int(duty_in));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(webio_tone_obj, webio_tone);
+
+static mp_obj_t webio_tone_stop(void) {
+    webio_js_tone_stop();
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(webio_tone_stop_obj, webio_tone_stop);
+
+static mp_obj_t webio_audio_play(mp_obj_t path_in, mp_obj_t volume_in) {
+    webio_js_audio_init();
+    return mp_obj_new_bool(webio_js_audio_play(
+        mp_obj_str_get_str(path_in), mp_obj_get_int(volume_in)
+    ));
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(webio_audio_play_obj, webio_audio_play);
+
+static mp_obj_t webio_audio_stop(void) {
+    webio_js_audio_stop();
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(webio_audio_stop_obj, webio_audio_stop);
+
+static mp_obj_t webio_audio_volume(mp_obj_t volume_in) {
+    webio_js_audio_volume(mp_obj_get_int(volume_in));
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(webio_audio_volume_obj, webio_audio_volume);
+
 static const mp_rom_map_elem_t webio_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR__webio) },
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&webio_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_leds_write), MP_ROM_PTR(&webio_leds_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_buttons), MP_ROM_PTR(&webio_buttons_obj) },
     { MP_ROM_QSTR(MP_QSTR_joystick), MP_ROM_PTR(&webio_joystick_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tone), MP_ROM_PTR(&webio_tone_obj) },
+    { MP_ROM_QSTR(MP_QSTR_tone_stop), MP_ROM_PTR(&webio_tone_stop_obj) },
+    { MP_ROM_QSTR(MP_QSTR_audio_play), MP_ROM_PTR(&webio_audio_play_obj) },
+    { MP_ROM_QSTR(MP_QSTR_audio_stop), MP_ROM_PTR(&webio_audio_stop_obj) },
+    { MP_ROM_QSTR(MP_QSTR_audio_volume), MP_ROM_PTR(&webio_audio_volume_obj) },
 };
 static MP_DEFINE_CONST_DICT(webio_module_globals, webio_module_globals_table);
 

--- a/scripts/web_port/staged_lib/_web_machine_hw.py
+++ b/scripts/web_port/staged_lib/_web_machine_hw.py
@@ -7,6 +7,8 @@
 
 import time
 
+import _webio
+
 
 def unique_id():
     return b"webbuild"
@@ -51,28 +53,38 @@ class PWM:
         self._pin = pin
         self._freq = freq
         self._duty = duty_u16
+        self._audio = getattr(pin, "_id", None) == -1
+        self._update_audio()
+
+    def _update_audio(self):
+        if self._audio:
+            _webio.tone(self._freq, self._duty)
 
     def freq(self, value=None):
         if value is None:
             return self._freq
         self._freq = value
+        self._update_audio()
 
     def duty(self, value=None):
         if value is None:
             return self._duty >> 6
         self._duty = value << 6
+        self._update_audio()
 
     def duty_u16(self, value=None):
         if value is None:
             return self._duty
         self._duty = value
+        self._update_audio()
 
     def duty_ns(self, value=None):
         if value is None:
             return 0
 
     def deinit(self):
-        pass
+        if self._audio:
+            _webio.tone_stop()
 
 
 class ADC:

--- a/tests/test_graphical_open_with_file_manager.py
+++ b/tests/test_graphical_open_with_file_manager.py
@@ -14,7 +14,6 @@ import mpos.ui
 from mpos import (
     AppManager,
     click_label,
-    wait_for_render,
     wait_for_text,
 )
 from mpos.activity_navigator import get_foreground_app
@@ -42,7 +41,10 @@ class TestGraphicalOpenWithFileManager(unittest.TestCase):
         os.mkdir(self.test_path)
         for name in ("sample.wav", "sample.png", "sample.txt", "sample.rtttl"):
             with open("{}/{}".format(self.test_path, name), "wb") as f:
-                f.write(b"dummy")
+                if name == "sample.rtttl":
+                    f.write(b"sample:d=4,o=5,b=120:c")
+                else:
+                    f.write(b"dummy")
 
     def tearDown(self):
         """Go back to the launcher and remove the temporary files."""
@@ -84,14 +86,14 @@ class TestGraphicalOpenWithFileManager(unittest.TestCase):
             "Foreground app is not Music Player",
         )
 
-    def test_rtttl_file_opens_music_player_without_buzzer(self):
-        """Clicking a .rtttl file should launch Music Player and report the missing buzzer output."""
+    def test_rtttl_file_opens_music_player(self):
+        """Clicking a .rtttl file should launch the Music Player app."""
         self._start_file_manager()
 
         self.assertTrue(click_label("sample.rtttl"), "Could not click sample.rtttl")
         self.assertTrue(
-            wait_for_text("RTTTL requires a buzzer output", timeout=10),
-            "Music Player did not show buzzer-required error",
+            wait_for_text("Stop", timeout=10),
+            "Music Player did not open",
         )
         self.assertEqual(
             get_foreground_app(),


### PR DESCRIPTION
## Summary

- add browser Web Audio playback for PCM and IMA ADPCM WAV files
- add browser buzzer/RTTTL playback through a Web Audio oscillator
- run web RTTTL and WAV completion monitoring asynchronously so LVGL stays responsive
- add virtual buzzer registration for web and desktop builds
- render RTTTL to WAV for native Linux/macOS playback
- support stop and live volume updates through the browser audio bridge

Tested out by locally building the web target and running the Music and the The Free Lantern app. Verified by my ears receiving the correct vibrations.

Note: 50% volume on the Music app made me think it was broken, but it's just _very_ quiet. Pop it over to 100% to test it out and it should work! Same for the The Free Lantern app.