### PR TITLE
build_mpos.sh: restore native/viper decorators after desktop builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ OS:
 - sdl_keyboard: fix CTRL-C and CTRL-V on textarea if set_text_selection(True)
 
 Development:
+- build_mpos.sh: restore @micropython.native/@micropython.viper decorators after desktop/web builds (via EXIT trap) so local builds no longer leave the working tree modified
 - Add Python-level line coverage via sys.settrace (mpcov build variant)
 - Add `--coverage` flag to test_runner.py for collecting per-file line coverage
 - Add `make build-mpos-unix-coverage` target

--- a/scripts/build_mpos.sh
+++ b/scripts/build_mpos.sh
@@ -19,6 +19,21 @@ disable_native_viper() {
 	find -L "$1" -name '*.py.bak' -type f -exec rm -f {} +
 }
 
+restore_native_viper() {
+	# Reverse of disable_native_viper: uncomment the decorators it commented
+	# out, so a desktop/web build doesn't leave every native/viper-using file
+	# in the working tree modified. Invoked via an EXIT trap so the restore
+	# also runs when the build fails or is interrupted.
+	echo "Restoring @micropython.native/@micropython.viper decorators..."
+	find -L "$1" -name '*.py' -type f -print0 | while IFS= read -r -d '' f; do
+		if [ -L "$f" ]; then
+			continue
+		fi
+		sed -i.bak -E 's/^([[:space:]]*)#(@micropython\.(native|viper)[[:space:]]*)$/\1\2/' "$f"
+	done
+	find -L "$1" -name '*.py.bak' -type f -exec rm -f {} +
+}
+
 apply_patch() {
 	# $1 = dir to patch in, $2 = patch file. Fails the build when a required
 	# patch neither applies forward nor is already applied, instead of
@@ -210,6 +225,11 @@ if [ "$target" == "unix" -o "$target" == "macOS" -o "$target" == "web" ]; then
 	# Native/viper decorators are unsupported by the WASM/native emitter used for
 	# the web port, so disable them before freezing.
 	disable_native_viper "$codebasedir/internal_filesystem"
+	# The decorators are baked out of the frozen bytecode above; once the
+	# build ends the source tree should go back to normal. EXIT trap covers
+	# success, build failure, and CTRL-C — without this, every desktop/web
+	# build left the native/viper-using files modified in git.
+	trap 'restore_native_viper "$codebasedir/internal_filesystem"' EXIT
 fi
 
 if [ ! -f "$codebasedir"/lvgl_micropython/lib/micropython/mpy-cross/build/mpy-cross ]; then


### PR DESCRIPTION
## Summary

`disable_native_viper()` comments out `@micropython.native` / `@micropython.viper` across `internal_filesystem/` for the unix, macOS, and web targets (the decorators must not be frozen), but nothing ever reverses the edit. In CI that's harmless — the checkout is throwaway, and the esp32 builds run first so they keep the optimized decorators. For local development, every desktop/web build leaves the touched files (`draw.py`, `appstore/blurhash.py`, `mpos/audio/adpcm_ima.py`, `mpos/audio/stream_wav.py`, ...) modified in git, which is easy to mistake for real work — or worse, to accidentally commit or discard alongside real work.

This adds `restore_native_viper()` as the exact inverse (uncomment the decorators the disable step commented out) and invokes it via an **EXIT trap**, so the tree is restored on build success, build failure, and CTRL-C alike. The trap is only installed after `disable_native_viper` has actually run, and the restore happens after freezing, so the frozen bytecode is unaffected.

## Test plan

- [x] Round-trip test: a file containing both `@micropython.native` (column 0) and an indented `@staticmethod`-stacked `@micropython.viper` is byte-identical after disable + restore
- [x] `scripts/build_mpos.sh macOS` completes and `git status` shows no modified `internal_filesystem/` files afterwards

## Merge checklist

- CHANGELOG.md updated under "Future release" (Development section)
- No settings/app changes; no test changes applicable (shell build script)

🤖 Generated with [Claude Code](https://claude.com/claude-code), running with bypass permissions enabled