### PR TITLE
scripts/mpos_controller: give the serial port to mpremote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ OS:
 - micropython-nostr: log background relay connection failures at INFO instead of ERROR to avoid REPL pollution breaking file transfers
 
 Development:
+- mpos_controller: give --serial-port to mpremote, so file transfers, screenshots and widget trees use the selected device instead of the first device that mpremote finds
 - Add Python-level line coverage via sys.settrace (mpcov build variant)
 - Add `--coverage` flag to test_runner.py for collecting per-file line coverage
 - Add `make build-mpos-unix-coverage` target

--- a/scripts/mpos_controller.py
+++ b/scripts/mpos_controller.py
@@ -75,11 +75,19 @@ def _mpremote_cmd(port=None, *rest):
 
 
 def _count_usb_serial_devices():
-    """Count the attached USB serial devices, or give 0 if the count is unknown."""
+    """
+    Count the attached USB serial devices, or give None if the count is unknown.
+
+    The count is unknown when pyserial is missing from *this* interpreter.
+    That does not mean the host has no devices: _mpremote_cmd() starts
+    mpremote with `python3`, which can be a different interpreter that does
+    have pyserial. A missing pyserial therefore gives None, and not 0, so
+    that the caller does not read it as "the host has no devices".
+    """
     try:
         import serial.tools.list_ports
     except ImportError:
-        return 0
+        return None
     return sum(
         1 for p in serial.tools.list_ports.comports()
         if p.vid is not None and p.pid is not None
@@ -1291,28 +1299,23 @@ for s in t:
     def run_test_file(self, test_path, tests_dir=None, timeout=300):
         import subprocess, re
         code = _build_test_code(test_path, tests_dir)
-        mpremote = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "..",
-            "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py",
-        )
         host_test_dir = os.path.dirname(os.path.abspath(test_path))
         mpk_names = set(re.findall(r"\.\./tests/(com\.micropythonos\.ziptest_[^\"]+\.mpk)", code))
         if mpk_names:
             subprocess.run(
-                ["python3", mpremote, "connect", self.port, "exec",
-                 "import os; os.mkdir('tests')"],
+                _mpremote_cmd(self.port, "exec", "import os; os.mkdir('tests')"),
                 capture_output=True, timeout=15,
             )
             for name in sorted(mpk_names):
                 host_mpk = os.path.join(host_test_dir, name)
                 subprocess.run(
-                    ["python3", mpremote, "connect", self.port, "cp",
-                     host_mpk, ":tests/{}".format(name)],
+                    _mpremote_cmd(self.port, "cp",
+                                  host_mpk, ":tests/{}".format(name)),
                     capture_output=True, timeout=60,
                 )
             code = code.replace("../tests/", "tests/")
         result = subprocess.run(
-            ["python3", mpremote, "connect", self.port, "exec", code],
+            _mpremote_cmd(self.port, "exec", code),
             capture_output=True, timeout=timeout + 60,
         )
         out = result.stdout
@@ -1580,16 +1583,26 @@ def main():
             return 1
         apppath = args.args[0]
         import subprocess, os
-        if not args.serial_port and _count_usb_serial_devices() > 1:
-            print(
-                "error: the host has more than one USB serial device and you "
-                "gave no --serial-port.\n"
-                "       mpremote would select the first device, which can be "
-                "the incorrect one.\n"
-                "       Run 'mpremote connect list' and give --serial-port.",
-                file=sys.stderr,
-            )
-            return 1
+        if not args.serial_port:
+            device_count = _count_usb_serial_devices()
+            if device_count is None:
+                print(
+                    "warning: pyserial is not available here, so the number of "
+                    "USB serial devices is unknown.\n"
+                    "         mpremote selects the first device. Give "
+                    "--serial-port to select a device.",
+                    file=sys.stderr,
+                )
+            elif device_count > 1:
+                print(
+                    "error: the host has more than one USB serial device and "
+                    "you gave no --serial-port.\n"
+                    "       mpremote would select the first device, which can "
+                    "be the incorrect one.\n"
+                    "       Run 'mpremote connect list' and give --serial-port.",
+                    file=sys.stderr,
+                )
+                return 1
         print("Installing to {}".format(args.serial_port or "the first device"))
         subprocess.run(
             _mpremote_cmd(args.serial_port, "mkdir", ":/apps"), capture_output=True

--- a/scripts/mpos_controller.py
+++ b/scripts/mpos_controller.py
@@ -55,6 +55,37 @@ def _resolve_cwd():
     return os.path.normpath(os.path.join(d, "..", "internal_filesystem"))
 
 
+def _mpremote_cmd(port=None, *rest):
+    """
+    Build an mpremote command, with the port when the port is known.
+
+    If the command has no `connect`, mpremote uses `connect auto`. That
+    selects sorted(comports())[0], which is the first USB serial device by
+    name. If the host has two devices, that device can be the incorrect one.
+    Because of this, each caller that knows the port must give the port here.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    mpremote = os.path.normpath(os.path.join(
+        script_dir, "..",
+        "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py"))
+    cmd = ["python3", mpremote]
+    if port:
+        cmd += ["connect", port]
+    return cmd + list(rest)
+
+
+def _count_usb_serial_devices():
+    """Count the attached USB serial devices, or give 0 if the count is unknown."""
+    try:
+        import serial.tools.list_ports
+    except ImportError:
+        return 0
+    return sum(
+        1 for p in serial.tools.list_ports.comports()
+        if p.vid is not None and p.pid is not None
+    )
+
+
 def _build_test_code(test_path, tests_dir=None):
     with open(test_path) as f:
         test_content = f.read()
@@ -1076,11 +1107,8 @@ class SerialBackend:
         import subprocess, tempfile, os as _os
         with tempfile.NamedTemporaryFile(suffix=".raw", delete=False) as tmp:
             tmppath = tmp.name
-        script_dir = _os.path.dirname(_os.path.abspath(__file__))
-        mpremote = _os.path.join(script_dir, "..",
-            "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py")
         subprocess.run(
-            ["python3", mpremote, "cp", ":{}".format(path), tmppath],
+            _mpremote_cmd(self.port, "cp", ":{}".format(path), tmppath),
             capture_output=True, timeout=60
         )
         with open(tmppath, "rb") as f:
@@ -1094,11 +1122,8 @@ class SerialBackend:
             tmppath = tmp.name
         with open(tmppath, "wb") as f:
             f.write(data)
-        script_dir = _os.path.dirname(_os.path.abspath(__file__))
-        mpremote = _os.path.join(script_dir, "..",
-            "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py")
         subprocess.run(
-            ["python3", mpremote, "cp", tmppath, ":{}".format(path)],
+            _mpremote_cmd(self.port, "cp", tmppath, ":{}".format(path)),
             capture_output=True, timeout=60
         )
         _os.unlink(tmppath)
@@ -1222,11 +1247,8 @@ print("OK")
             import subprocess, json as _json, tempfile, os as _os
             with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
                 tmppath = tmp.name
-            script_dir = _os.path.dirname(_os.path.abspath(__file__))
-            mpremote = _os.path.join(script_dir, "..",
-                "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py")
             subprocess.run(
-                ["python3", mpremote, "cp", ":/_mpos_tree.json", tmppath],
+                _mpremote_cmd(self.port, "cp", ":/_mpos_tree.json", tmppath),
                 capture_output=True, timeout=15
             )
             with open(tmppath) as f:
@@ -1558,12 +1580,22 @@ def main():
             return 1
         apppath = args.args[0]
         import subprocess, os
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        mpremote = os.path.join(script_dir, "..",
-            "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py")
-        subprocess.run(["python3", mpremote, "mkdir", ":/apps"], capture_output=True)
+        if not args.serial_port and _count_usb_serial_devices() > 1:
+            print(
+                "error: the host has more than one USB serial device and you "
+                "gave no --serial-port.\n"
+                "       mpremote would select the first device, which can be "
+                "the incorrect one.\n"
+                "       Run 'mpremote connect list' and give --serial-port.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Installing to {}".format(args.serial_port or "the first device"))
+        subprocess.run(
+            _mpremote_cmd(args.serial_port, "mkdir", ":/apps"), capture_output=True
+        )
         result = subprocess.run(
-            ["python3", mpremote, "fs", "cp", "-r", apppath, ":/apps/"],
+            _mpremote_cmd(args.serial_port, "fs", "cp", "-r", apppath, ":/apps/"),
             capture_output=True, timeout=60
         )
         if result.returncode != 0:

--- a/tests/cpython_mpos_controller.py
+++ b/tests/cpython_mpos_controller.py
@@ -24,7 +24,11 @@ import argparse
 import subprocess
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from scripts.mpos_controller import MPOSController, _mpremote_cmd
+from scripts.mpos_controller import (
+    MPOSController,
+    _count_usb_serial_devices,
+    _mpremote_cmd,
+)
 
 
 PASS = 0
@@ -111,6 +115,28 @@ def test_mpremote_port(mpos, is_serial=False, cli_binary=None, serial_port=None)
         cmd[-4:] == ["fs", "cp", "app.py", ":/"],
         "with no port: the command keeps the other arguments",
     )
+
+    # A missing pyserial must give None, and not 0. The installapp guard reads
+    # 0 as "the host has one device or no device", and then does not warn.
+    # mpremote runs with `python3`, which can be a different interpreter that
+    # does have pyserial, so 0 would hide a real multi-device condition.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_serial(name, *a, **k):
+        if name.split(".")[0] == "serial":
+            raise ImportError("blocked by the test")
+        return real_import(name, *a, **k)
+
+    builtins.__import__ = no_serial
+    try:
+        check(
+            _count_usb_serial_devices() is None,
+            "no pyserial: the device count is unknown, and not 0",
+        )
+    finally:
+        builtins.__import__ = real_import
 
 
 def test_basic(mpos, is_serial=False, cli_binary=None, serial_port=None):

--- a/tests/cpython_mpos_controller.py
+++ b/tests/cpython_mpos_controller.py
@@ -24,7 +24,7 @@ import argparse
 import subprocess
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from scripts.mpos_controller import MPOSController
+from scripts.mpos_controller import MPOSController, _mpremote_cmd
 
 
 PASS = 0
@@ -69,6 +69,7 @@ def run_tests(mpos, only=None, is_serial=False, cli_binary=None, serial_port=Non
         "navigation": test_app_navigation,
         "appmanagement": test_app_management,
         "helpers": test_controller_helpers,
+        "mpremoteport": test_mpremote_port,
     }
     if only:
         names = [s.strip() for s in only.split(",")]
@@ -83,6 +84,33 @@ def run_tests(mpos, only=None, is_serial=False, cli_binary=None, serial_port=Non
     else:
         for name, fn in sections.items():
             fn(mpos, is_serial=is_serial, cli_binary=cli_binary, serial_port=serial_port)
+
+
+def test_mpremote_port(mpos, is_serial=False, cli_binary=None, serial_port=None):
+    # This test does not use a device, because _mpremote_cmd() only builds a
+    # list of arguments. It runs with the desktop backend and with a device.
+    section("mpremote port selection")
+
+    cmd = _mpremote_cmd("/dev/ttyACM7", "fs", "cp", "app.py", ":/")
+    has_connect = "connect" in cmd
+    check(has_connect, "with a port: the command contains 'connect'")
+    check(
+        has_connect and cmd[cmd.index("connect") + 1] == "/dev/ttyACM7",
+        "with a port: the port comes after 'connect'",
+    )
+    check(
+        cmd[-4:] == ["fs", "cp", "app.py", ":/"],
+        "with a port: the command keeps the other arguments",
+    )
+
+    # With no port, mpremote connects to the first device that it finds. The
+    # command must not contain 'connect', because there is no port to give.
+    cmd = _mpremote_cmd(None, "fs", "cp", "app.py", ":/")
+    check("connect" not in cmd, "with no port: the command contains no 'connect'")
+    check(
+        cmd[-4:] == ["fs", "cp", "app.py", ":/"],
+        "with no port: the command keeps the other arguments",
+    )
 
 
 def test_basic(mpos, is_serial=False, cli_binary=None, serial_port=None):
@@ -358,13 +386,13 @@ def test_app_management(mpos, is_serial=False, cli_binary=None, serial_port=None
                      "internal_filesystem/apps", appname)
     )
 
-    script_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    mpremote = os.path.join(script_dir,
-        "lvgl_micropython/lib/micropython/tools/mpremote/mpremote.py")
-
-    subprocess.run(["python3", mpremote, "mkdir", ":/apps"], capture_output=True)
+    # Use the port that the caller gave. If mpremote gets no port, it connects
+    # to the first serial device that it finds, which can be a different device.
+    subprocess.run(
+        _mpremote_cmd(serial_port, "mkdir", ":/apps"), capture_output=True
+    )
     result = subprocess.run(
-        ["python3", mpremote, "fs", "cp", "-r", apppath, ":/apps/"],
+        _mpremote_cmd(serial_port, "fs", "cp", "-r", apppath, ":/apps/"),
         capture_output=True, timeout=60
     )
     check(result.returncode == 0, f"installapp: cp exit code {result.returncode}")


### PR DESCRIPTION
## The problem

`MPOSController` accepts `--serial-port` for its own REPL connection. But it
started `mpremote` with no `connect` argument. `mpremote` then connects to the
first USB serial device that it finds:

```python
# main.py
def ensure_connected(self):
    if self.transport is None:
        do_connect(self)          # no args, so dev becomes "auto"

# commands.py
elif dev == "auto":
    for p in sorted(serial.tools.list_ports.comports()):
        if p.vid is not None and p.pid is not None:
            state.transport = SerialTransport(p.device, baudrate=115200)
            return
```

The REPL connection used the correct port, because it uses pyserial directly.
Only the file transfers used the incorrect port.

## Why this is difficult to find

If the host has one device, that device is always the correct device. The
problem stays hidden. If the host has two devices, `mpremote` sends the files
to the incorrect device.

`mpremote` sorts the devices by name. Because of this, it selects the same
incorrect device each time. A random selection is more safe: it fails only some
of the time, and the user then examines the connection quickly. This selection
fails all of the time. The user sees no error, and sees no change on the
correct device. The user then examines the application code, and does not
examine the connection.

## How to see the problem

1. Connect two devices to the host.
2. Give this command:
   `python3 scripts/mpos_controller.py --serial-port <the second device> installapp <path>`
3. Examine the two devices. The first device has the new files.

## The change

Four functions started `mpremote` without the port:

| Function | Command | Used by |
| --- | --- | --- |
| `main()`, installapp action | `mkdir`, `fs cp -r` | app installation |
| `SerialBackend._read_remote_file` | `cp :path tmp` | `screenshot()` |
| `SerialBackend.write_remote_file` | `cp tmp :path` | `write_file()` |
| `SerialBackend.get_widget_tree` | `cp :/_mpos_tree.json tmp` | widget tree |

Because `screenshot()` and `get_widget_tree()` also used the incorrect device,
a host with two devices showed the old screen after a correct installation.
This gave more incorrect data to the user.

All four functions now build the command with a new `_mpremote_cmd()` helper.
The helper puts `connect <port>` in the command when the port is known.

`SerialBackend.run_test_file()` is newer code, and it already gives
`connect self.port` to mpremote. This change makes the four older functions do
the same thing. I did not change `run_test_file()`, because it is correct.

The installapp action also stops and gives an error message if the user gives
no `--serial-port` and the host has more than one device. It is not possible to
select the correct device in that condition.

`tests/cpython_mpos_controller.py` had the same problem. The app management
test received a `serial_port` argument, but it did not use that argument.

## Tests

A new `mpremoteport` section tests `_mpremote_cmd()`. It does not use a device,
so it runs with the desktop backend:

```
$ python3 tests/cpython_mpos_controller.py --only mpremoteport
  [mpremote port selection]
  + with a port: the command contains 'connect'
  + with a port: the port comes after 'connect'
  + with a port: the command keeps the other arguments
  + with no port: the command contains no 'connect'
  + with no port: the command keeps the other arguments
```

To show that the test is sufficient, I replaced `_mpremote_cmd()` with the old
behaviour. Two of the five checks then failed.

I also tested the change with one device. The files went to that device.
I did not test with two devices, because I have only one device.

## Parts that this change does not correct

`scripts/install.sh` also starts `mpremote` with no `connect` argument. That
script has no port option, so it does not ignore a port that the user gave. It
always uses the first device. To correct it, it must get a new port option.
This is a change to its interface, so it is not in this pull request.

`AGENTS.md` also shows an `mpremote` command with no port. It has the same
condition.

## Checklist

- CHANGELOG.md: a new `Tools:` item is in the "Future release" section.
- Tests: a new test section, as shown above.
- `make lint`: all checks pass.
- Formatting: the new code keeps the style of the code near it. I did not run
  `ruff format` on these files, because the files were not formatted with it
  before this change. `make lint` and the CI workflow use `ruff check` only.
- MANIFEST.JSON and MAINTAINERS.md: no change, because this pull request does
  not change an app or a board.
