### PR TITLE
Audiomanager pwm

### DIFF
--- a/internal_filesystem/lib/mpos/audio/audiomanager.py
+++ b/internal_filesystem/lib/mpos/audio/audiomanager.py
@@ -763,10 +763,9 @@ class Player:
             self._stream.play()
             return
 
-        from machine import Pin, PWM
+        from machine import PWM
 
-        self._buzzer = PWM(Pin(self.output.buzzer_pin, Pin.OUT))
-        self._buzzer.duty_u16(0)
+        self._buzzer = PWM(self.output.buzzer_pin, duty_u16=0)
 
         on_complete = self.on_complete
         stream_class = RTTTLStream

--- a/internal_filesystem/lib/mpos/audio/audiomanager.py
+++ b/internal_filesystem/lib/mpos/audio/audiomanager.py
@@ -666,7 +666,10 @@ class Player:
             self._stream.stop()
         if self._buzzer:
             try:
+                from machine import Pin
                 self._buzzer.deinit()
+                Pin(self.output.buzzer_pin, Pin.IN)  # reconfigure buzzer_pin as INPUT to disassociate it from PWM
+                self._buzzer = None
             except Exception:
                 pass
         self._manager._session_finished(self)
@@ -730,7 +733,10 @@ class Player:
             if not (self._stream and getattr(self._stream, "runs_async", False)):
                 if self._buzzer:
                     try:
+                        from machine import Pin
                         self._buzzer.deinit()
+                        Pin(self.output.buzzer_pin, Pin.IN)  # reconfigure buzzer_pin as INPUT to disassociate it from PWM
+                        self._buzzer = None
                     except Exception:
                         pass
                 self._manager._session_finished(self)
@@ -775,6 +781,7 @@ class Player:
                     if self._buzzer:
                         try:
                             self._buzzer.deinit()
+                            self._buzzer = None
                         except Exception:
                             pass
                     self._manager._session_finished(self)


### PR DESCRIPTION
this fixes the buzzer buzzing along when the user create a PWM instance
it also fixes a clicking sound when the PWM is created

here is the code on how the pwm problem could be reproduced on fri3d-badges
```python
from machine import PWM, Pin
from time import sleep

buzzer_pin = 46  # 38 on fri3d-2026, 46 on fri3d-2024
pwm_pins = [46, 2, 15, 16, 17, 43, 44, 47]  # 38 on fri3d_2026, 46 on fri3d-2024
pwm_freq = 50

# this fails
# note buzzer pin is first in the list
print("this will sound the buzzer for every first PWM instance")
for pwm_pin in pwm_pins:
    print(f"PWM test {pwm_pin}")
    pwm = PWM(pwm_pin, freq=pwm_freq, duty_u16=32768)
    sleep(1)
    pwm.deinit()

# this works
# pin is reconfigured at the end after deinit
print("here the buzzer will be silent")
for pwm_pin in pwm_pins:
    print(f"PWM test {pwm_pin}")
    pwm = PWM(pwm_pin, freq=pwm_freq, duty_u16=32768)
    sleep(1)
    pwm.deinit()
    Pin(pwm_pin, Pin.IN)  # reconfigure buzzer_pin as INPUT to disassociate it from PWM
```
