### PR TITLE
Fix two LVGL memory leaks in activity navigation

### DIFF
--- a/internal_filesystem/lib/mpos/ui/view.py
+++ b/internal_filesystem/lib/mpos/ui/view.py
@@ -8,6 +8,11 @@ logger = logging.getLogger(__name__)
 
 screen_stack = []
 
+# Screen that outlived its activity because it was still on the display when
+# the activity was removed. It cannot be deleted right away, so the next
+# screen load frees it through LVGL's auto_del.
+_orphan_screen = None
+
 
 def close_top_layer_msgboxes():
     top = lv.layer_top()
@@ -22,7 +27,7 @@ def close_top_layer_msgboxes():
         i += 1
 
 def setContentView(new_activity, new_screen):
-    global screen_stack
+    global screen_stack, _orphan_screen
     if screen_stack:
         current_activity, current_screen, current_focusgroup, _ = screen_stack[-1]
         try:
@@ -50,7 +55,11 @@ def setContentView(new_activity, new_screen):
             show_app_error_dialog(
                 new_activity.appFullName, e, is_lifecycle=True
             )
-    lv.screen_load_anim(new_screen, lv.SCREEN_LOAD_ANIM.OVER_LEFT, 500, 0, False)
+    # An orphaned screen has no activity left to own it, so let the load
+    # animation delete it once it is off the display.
+    auto_del = _orphan_screen is not None and _orphan_screen == lv.screen_active()
+    _orphan_screen = None
+    lv.screen_load_anim(new_screen, lv.SCREEN_LOAD_ANIM.OVER_LEFT, 500, 0, auto_del)
     if new_activity:
         try:
             new_activity.onResume(new_screen)
@@ -68,6 +77,7 @@ def remove_and_stop_all_activities():
         remove_and_stop_current_activity()
 
 def remove_and_stop_current_activity():
+    global _orphan_screen
     current_activity, current_screen, current_focusgroup, _ = screen_stack.pop()
     if current_activity:
         try:
@@ -88,12 +98,32 @@ def remove_and_stop_current_activity():
         if current_screen:
             current_screen.clean()
 
+    # LVGL holds every group in a global list, so the focus group that
+    # setContentView() created for this activity needs an explicit delete().
+    if current_focusgroup:
+        current_focusgroup.delete()
+
+    # clean() empties a screen but keeps the screen object itself. Delete it,
+    # unless LVGL still points at it (shown, animating, or queued to load) —
+    # deleting those would leave a dangling pointer, so hand such a screen to
+    # the auto_del of the next screen load instead.
+    if current_screen:
+        display = lv.display_get_default()
+        if display and current_screen in (
+            display.get_screen_active(),
+            display.get_screen_prev(),
+            display.get_screen_loading(),
+        ):
+            _orphan_screen = current_screen
+        else:
+            current_screen.delete()
+
 def finish_current_activity():
     """Remove the current activity and resume the one below it.
 
     This is the direct "finish" path; it does not ask onBackPressed().
     """
-    global screen_stack
+    global screen_stack, _orphan_screen
 
     if len(screen_stack) <= 1:
         logger.warning("Can't finish — stack empty")
@@ -106,6 +136,8 @@ def finish_current_activity():
     # Load previous
     prev_activity, prev_screen, prev_focusgroup, prev_focused = screen_stack[-1]
     if __debug__: logger.debug("finish_current_activity got %s, %s, %s, %s", prev_activity, prev_screen, prev_focusgroup, prev_focused)
+    # auto_del below deletes the screen just popped, so it is no longer orphaned.
+    _orphan_screen = None
     lv.screen_load_anim(prev_screen, lv.SCREEN_LOAD_ANIM.OVER_RIGHT, 500, 0, True)
 
     default_group = lv.group_get_default()

--- a/tests/test_view_navigation_leaks.py
+++ b/tests/test_view_navigation_leaks.py
@@ -1,0 +1,113 @@
+"""Regression tests for LVGL resource leaks in the activity navigation stack.
+
+LVGL allocates from the MicroPython heap (lv_conf.h sets
+LV_USE_STDLIB_MALLOC = LV_STDLIB_MPY) and keeps its global state in a GC root,
+so anything LVGL never frees stays counted by gc.mem_alloc() forever.
+
+Two things were leaked:
+  * the per-activity focus group created by setContentView(). LVGL holds every
+    group in a global linked list, so only an explicit delete() frees it.
+  * the screens torn down by remove_and_stop_all_activities(). clean() only
+    deletes a screen's children, not the screen itself, and that path has no
+    screen_load_anim(..., auto_del=True) to do it either.
+"""
+
+import gc
+import unittest
+
+import lvgl as lv
+
+import mpos.ui.view as view
+from mpos.ui.testing import GraphicalTestCase
+
+
+def _is_deleted(obj):
+    """Report whether LVGL freed the object behind this binding wrapper.
+
+    The binding invalidates the wrapper on delete and raises LvReferenceError
+    on any later access.
+    """
+    try:
+        obj.get_child_count()
+    except Exception as e:
+        return type(e).__name__ == "LvReferenceError"
+    return False
+
+
+class _StubActivity:
+    """Minimal activity: the navigation stack only calls these lifecycle hooks."""
+
+    appFullName = "com.micropythonos.leaktest"
+
+    def onStart(self, screen): pass
+    def onResume(self, screen): pass
+    def onPause(self, screen): pass
+    def onStop(self, screen): pass
+    def onDestroy(self, screen): pass
+    def onBackPressed(self, screen): return False
+
+
+class TestNavigationLeaks(GraphicalTestCase):
+
+    # Enough task_handler iterations to outlast the 500 ms load animation.
+    ANIMATION_ITERATIONS = 70
+
+    def setUp(self):
+        super().setUp()
+        self._saved_stack = view.screen_stack[:]
+        del view.screen_stack[:]
+
+    def tearDown(self):
+        del view.screen_stack[:]
+        view.screen_stack.extend(self._saved_stack)
+        super().tearDown()
+
+    def _settle(self):
+        self.wait_for_render(self.ANIMATION_ITERATIONS)
+
+    def _push_and_pop(self):
+        view.setContentView(_StubActivity(), lv.obj())
+        self._settle()
+        view.finish_current_activity()
+        self._settle()
+
+    def test_back_navigation_does_not_leak(self):
+        view.setContentView(_StubActivity(), lv.obj())
+        self._settle()
+        # Warm up: the first round pulls in lazily imported modules.
+        self._push_and_pop()
+
+        gc.collect()
+        before = gc.mem_alloc()
+        rounds = 10
+        for _ in range(rounds):
+            self._push_and_pop()
+        gc.collect()
+        leaked = gc.mem_alloc() - before
+
+        print("leaked %d bytes over %d navigations" % (leaked, rounds))
+        self.assertTrue(
+            leaked < rounds * 32,
+            "leaked %d bytes over %d navigations" % (leaked, rounds),
+        )
+
+    def test_remove_all_activities_frees_its_screens(self):
+        first = lv.obj()
+        second = lv.obj()
+        view.setContentView(_StubActivity(), first)
+        self._settle()
+        view.setContentView(_StubActivity(), second)
+        self._settle()
+
+        view.remove_and_stop_all_activities()
+        # The next activity takes over the display, which releases the screen
+        # that was still shown when the stack was emptied.
+        view.setContentView(_StubActivity(), lv.obj())
+        self._settle()
+
+        self.assertTrue(_is_deleted(first), "screen below the top was not freed")
+        self.assertTrue(_is_deleted(second), "screen on display was not freed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Navigation leaked memory on two paths:

1. Focus groups. Each `setContentView()` creates a focus group. LVGL keeps all groups in a global list, and the list is a GC root. The GC can never free a group; only `delete()` can. No code called it. Each navigation leaked ~90 bytes.
2. Screens on the remove-all path. `remove_and_stop_all_activities()` only called `clean()`. `clean()` deletes the children of a screen, but keeps the screen. Only the back path freed screens, through `screen_load_anim(..., auto_del=True)`. Thus `restart_launcher()` leaked the full screen stack on each app install or uninstall.

## Fix

- Delete the focus group when the activity is removed.
- Delete the screen when the activity is removed, with one exception. A screen that LVGL still tracks (active, previous, or loading) must not be deleted directly: delete only clears the active-screen pointer, so the other two would dangle. Keep that screen as `_orphan_screen`. The next screen load frees it with `auto_del`.

I've also added a regression test: It measures heap growth across ten navigations, and checks that both screens die on the remove-all path. Both tests fail on `main` and pass with this change.

## Known limit

A `remove_and_stop_all_activities()` call in the middle of a screen animation can still leak one screen. This falls back to the old behavior; it cannot crash.