### PR TITLE
Add mpos module import and initialize io_expander in linux.py

### DIFF
--- a/internal_filesystem/lib/mpos/board/linux.py
+++ b/internal_filesystem/lib/mpos/board/linux.py
@@ -10,6 +10,7 @@ import sdl_display
 from drivers.indev.sdl_keyboard import MposSDLKeyboard
 
 import mpos.clipboard
+import mpos
 import mpos.ui
 import mpos.ui.focus_direction
 from mpos import InputManager
@@ -155,6 +156,7 @@ if _webio:
         from drivers.indev.fri3d_2026_expander import Fri3d2026Expander
 
         web_expander = WebExpander()
+        mpos.io_expander = web_expander
         web_buttons_indev = Fri3d2026Expander(web_expander)
         group = lv.group_get_default()
         if group:
@@ -237,6 +239,5 @@ CameraManager.add_camera(CameraManager.Camera(
 
 
 if __debug__: logger.debug("linux.py finished")
-
 
 


### PR DESCRIPTION
This is to able to use the buttons directly in MicroPython apps which are connected to the IO Expander chip.

```python
from mpos import Activity, TaskManager
import mpos
import lvgl as lv


class Main(Activity):
    def onCreate(self):
        self.screen = lv.obj()

        self.label = lv.label(self.screen)
        self.label.set_text("Press A, B, X or Y")
        self.label.center()

        self.buttons = {
            "A": 7,
            "B": 6,
            "Y": 8,
            "X": 9,
        }

        self.previous = {
            name: False for name in self.buttons
        }

        self.setContentView(self.screen)
        TaskManager.create_task(self.read_buttons())

    async def read_buttons(self):
        while True:
            digital = mpos.io_expander.digital

            for name, index in self.buttons.items():
                pressed = digital[index]

                if pressed and not self.previous[name]:
                    self.label.set_text(name + " pressed")
                    self.label.center()

                self.previous[name] = pressed

            await TaskManager.sleep_ms(20)

    def onBackPressed(self, screen):
        self.label.set_text("X pressed")
        self.label.center()
        return True
```