### PR TITLE
Fix UNIHIKER K10 two-button navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Future release (next version)
 =====
 
+Board Support:
+- UNIHIKER K10: improve two-button navigation, correct camera preview orientation, and restore button input after camera operations
+
 Builtin Apps:
 - AppStore: fix cooldown blocking the first update check for 60s after boot on ESP32 (ticks_ms counts from boot)
 - OSUPDater: fix cooldown blocking the first update check for 60s after boot on ESP32 (ticks_ms counts from boot)
@@ -24,7 +27,6 @@ Builtin Apps:
 
 Frameworks:
 - View: fix two LVGL memory leaks in activity navigation by @fdb
-
 0.17.2
 ======
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Builtin Apps:
 
 Frameworks:
 - View: fix two LVGL memory leaks in activity navigation by @fdb
+
 0.17.2
 ======
 

--- a/internal_filesystem/builtin/apps/com.micropythonos.howto/howto.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.howto/howto.py
@@ -49,7 +49,7 @@ class HowTo(Activity):
         if DeviceInfo.get_hardware_id() == "unihiker_k10":
             # K10 uses B as its only NEXT key, so static help text stays out of
             # its focus cycle and must remain compact enough to fit on one screen.
-            self._add_label(screen, "B: next. Hold B in a list: previous.", focusable=False)
+            self._add_label(screen, "Open a drop-down: B next. Hold B: previous.", focusable=False)
             self._add_label(screen, "A: select. Hold A: cancel or go back.", focusable=False)
         elif InputManager.has_pointer():
             self._add_label(screen, touchhelp)

--- a/internal_filesystem/builtin/apps/com.micropythonos.howto/howto.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.howto/howto.py
@@ -1,6 +1,6 @@
 import logging
 
-from mpos import Activity, SharedPreferences, DisplayMetrics, add_focus_highlight
+from mpos import Activity, DeviceInfo, SharedPreferences, DisplayMetrics, add_focus_highlight
 import lvgl as lv
 
 logger = logging.getLogger(__name__)
@@ -10,6 +10,7 @@ class HowTo(Activity):
     appname = "com.micropythonos.howto"
 
     dontshow_checkbox = None
+    closebutton = None
     prefs = None
 
     def onCreate(self):
@@ -17,22 +18,28 @@ class HowTo(Activity):
         screen.set_style_border_width(0, lv.PART.MAIN)
         screen.set_flex_flow(lv.FLEX_FLOW.COLUMN)
         screen.set_style_pad_all(DisplayMetrics.pct_of_width(5), lv.PART.MAIN)
-        # Children (labels, checkbox, button) are auto-added to the default group;
-        # the screen itself must NOT be in the group, otherwise move_focus_direction
-        # cannot find widgets below it (the fullscreen rect blocks spatial navigation).
-        preamble = "How to Navigate"
+        # Only actionable controls should go into the focus group.
+        preamble = "Navigate"
         self._add_label(screen, preamble, is_header=True)
 
-        buttonhelp_intro = "As you don't have a touch screen, you need to use the buttons to navigate:"
         buttonhelp_items = [
-            "If you have a joystick and at least 2 buttons, then use the joystick to move around. Use one of the buttons to ENTER and another to go BACK.",
-            "If you have 3 buttons, then one is PREVIOUS, one is ENTER and one is NEXT. To go back, press PREVIOUS and NEXT together.",
-            "If you have just 2 buttons, then one is PREVIOUS, the other is NEXT. To ENTER, press both at the same time. To go back, long-press the PREVIOUS button.",
+            "Joystick: move. Btns: ENTER/BACK.",
+            "3 buttons: PREV/ENTER/NEXT.",
+            "2 buttons: PREV/NEXT.",
         ]
-        touchhelp = "Swipe from the left edge to go back and from the top edge to open the menu."
+        buttonhelp_intro = "Use buttons to navigate:"
+        touchhelp = "Left/back. Menu top."
         from mpos import InputManager
+        try:
+            is_k10 = DeviceInfo.get_hardware_id() == "unihiker_k10"
+        except Exception:
+            is_k10 = False
         if InputManager.has_pointer():
             self._add_label(screen, touchhelp)
+        elif is_k10:
+            self._add_label(screen, "K")
+            self._add_label(screen, "- B: next.")
+            self._add_label(screen, "- A: select.")
         else:
             self._add_label(screen, buttonhelp_intro)
             for item in buttonhelp_items:
@@ -40,12 +47,15 @@ class HowTo(Activity):
 
         self.dontshow_checkbox = lv.checkbox(screen)
         self.dontshow_checkbox.set_text("Don't show again")
+        add_focus_highlight(self.dontshow_checkbox)
 
         closebutton = lv.button(screen)
+        self.closebutton = closebutton
         closebutton.add_event_cb(lambda *args: self.finish(), lv.EVENT.CLICKED, None)
         closebutton.add_event_cb(self._on_long_press, lv.EVENT.LONG_PRESSED, None)
         closelabel = lv.label(closebutton)
         closelabel.set_text("Close")
+        add_focus_highlight(closebutton)
 
         self.setContentView(screen)
 
@@ -54,8 +64,6 @@ class HowTo(Activity):
         label.set_width(lv.pct(100))
         label.set_text(text)
         label.set_long_mode(lv.label.LONG_MODE.WRAP)
-        add_focus_highlight(label)
-        lv.group_get_default().add_obj(label)
         if is_header:
             label.set_style_text_font(lv.font_montserrat_24, lv.PART.MAIN)
             label.set_style_margin_bottom(4, lv.PART.MAIN)
@@ -76,6 +84,12 @@ class HowTo(Activity):
             self.dontshow_checkbox.remove_state(lv.STATE.CHECKED)
         else:
             self.dontshow_checkbox.add_state(lv.STATE.CHECKED)
+
+        if self.closebutton:
+            try:
+                lv.group_focus_obj(self.closebutton)
+            except Exception:
+                pass
 
     def onPause(self, screen):
         if __debug__: logger.debug("howto app onPause called")

--- a/internal_filesystem/builtin/apps/com.micropythonos.howto/howto.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.howto/howto.py
@@ -18,33 +18,47 @@ class HowTo(Activity):
         screen.set_style_border_width(0, lv.PART.MAIN)
         screen.set_flex_flow(lv.FLEX_FLOW.COLUMN)
         screen.set_style_pad_all(DisplayMetrics.pct_of_width(5), lv.PART.MAIN)
-        # Only actionable controls should go into the focus group.
-        preamble = "Navigate"
-        self._add_label(screen, preamble, is_header=True)
+        self._add_label(
+            screen,
+            "How to Navigate",
+            is_header=True,
+            focusable=DeviceInfo.get_hardware_id() != "unihiker_k10",
+        )
 
         buttonhelp_items = [
-            "Joystick: move. Btns: ENTER/BACK.",
-            "3 buttons: PREV/ENTER/NEXT.",
-            "2 buttons: PREV/NEXT.",
+            (
+                "If you have a joystick and at least 2 buttons, then use the joystick "
+                "to move around. Use one of the buttons to ENTER and another to go BACK."
+            ),
+            (
+                "If you have 3 buttons, then one is PREVIOUS, one is ENTER and one "
+                "is NEXT. To go back, press PREVIOUS and NEXT together."
+            ),
+            (
+                "If you have just 2 buttons, then one is PREVIOUS, the other is NEXT. "
+                "To ENTER, press both at the same time. To go back, long-press the "
+                "PREVIOUS button."
+            ),
         ]
-        buttonhelp_intro = "Use buttons to navigate:"
-        touchhelp = "Left/back. Menu top."
+        buttonhelp_intro = "As you don't have a touch screen, you need to use the buttons to navigate:"
+        touchhelp = (
+            "Swipe from the left edge to go back. Swipe down from the top edge to "
+            "open the menu."
+        )
         from mpos import InputManager
-        try:
-            is_k10 = DeviceInfo.get_hardware_id() == "unihiker_k10"
-        except Exception:
-            is_k10 = False
-        if InputManager.has_pointer():
+        if DeviceInfo.get_hardware_id() == "unihiker_k10":
+            # K10 uses B as its only NEXT key, so static help text stays out of
+            # its focus cycle and must remain compact enough to fit on one screen.
+            self._add_label(screen, "B: next. Hold B in a list: previous.", focusable=False)
+            self._add_label(screen, "A: select. Hold A: cancel or go back.", focusable=False)
+        elif InputManager.has_pointer():
             self._add_label(screen, touchhelp)
-        elif is_k10:
-            self._add_label(screen, "K")
-            self._add_label(screen, "- B: next.")
-            self._add_label(screen, "- A: select.")
         else:
             self._add_label(screen, buttonhelp_intro)
             for item in buttonhelp_items:
                 self._add_label(screen, f"• {item}")
 
+        # Register the only actionable controls for keypad navigation.
         self.dontshow_checkbox = lv.checkbox(screen)
         self.dontshow_checkbox.set_text("Don't show again")
         add_focus_highlight(self.dontshow_checkbox)
@@ -59,7 +73,7 @@ class HowTo(Activity):
 
         self.setContentView(screen)
 
-    def _add_label(self, parent, text, is_header=False):
+    def _add_label(self, parent, text, is_header=False, focusable=True):
         label = lv.label(parent)
         label.set_width(lv.pct(100))
         label.set_text(text)
@@ -70,6 +84,8 @@ class HowTo(Activity):
         else:
             label.set_style_text_font(lv.font_montserrat_14, lv.PART.MAIN)
             label.set_style_margin_bottom(2, lv.PART.MAIN)
+        if focusable:
+            add_focus_highlight(label)
         return label
 
     def _on_long_press(self, event):
@@ -85,11 +101,9 @@ class HowTo(Activity):
         else:
             self.dontshow_checkbox.add_state(lv.STATE.CHECKED)
 
-        if self.closebutton:
-            try:
-                lv.group_focus_obj(self.closebutton)
-            except Exception:
-                pass
+        if DeviceInfo.get_hardware_id() == "unihiker_k10" and self.closebutton:
+            # Make the exit action immediately reachable on the two-button K10.
+            lv.group_focus_obj(self.closebutton)
 
     def onPause(self, screen):
         if __debug__: logger.debug("howto app onPause called")

--- a/internal_filesystem/builtin/apps/com.micropythonos.launcher/launcher.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.launcher/launcher.py
@@ -202,6 +202,7 @@ class Launcher(Activity):
     def _focus_first_usable_app(self):
         for fullname, target in self._app_cont_map.items():
             if fullname == "com.micropythonos.howto":
+                # K10 should resume on a launchable app instead of the startup HowTo.
                 continue
             if target:
                 lv.group_focus_obj(target)

--- a/internal_filesystem/builtin/apps/com.micropythonos.launcher/launcher.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.launcher/launcher.py
@@ -3,7 +3,8 @@ import lvgl as lv
 import math
 import time
 
-from mpos import AppearanceManager, AppManager, Activity, DisplayMetrics, add_focus_highlight
+from mpos import AppearanceManager, AppManager, Activity, DeviceInfo, DisplayMetrics, add_focus_highlight
+from mpos.ui.focus import enable_focus_borders
 
 logger = logging.getLogger(__name__)
 
@@ -21,9 +22,17 @@ class Launcher(Activity):
         self._splash_fullname = None        # fullname of the app being launched (splash shown)
         self._splash_screen = None          # temporary splash screen shown before app launch
         self._screen = None                 # the launcher's own screen object
+        self._k10 = False
 
     def onCreate(self):
         if __debug__: logger.debug("onCreate")
+
+        try:
+            self._k10 = DeviceInfo.get_hardware_id() == "unihiker_k10"
+        except Exception:
+            self._k10 = False
+        if self._k10:
+            enable_focus_borders()
 
         main_screen = lv.obj()
         main_screen.set_style_border_width(0, lv.PART.MAIN)
@@ -90,6 +99,7 @@ class Launcher(Activity):
             app_cont.set_style_pad_all(0, lv.PART.MAIN)
             app_cont.set_style_bg_opa(lv.OPA.TRANSP, lv.PART.MAIN)
             app_cont.set_scrollbar_mode(lv.SCROLLBAR_MODE.OFF)
+            app_cont.add_flag(lv.obj.FLAG.CLICKABLE)
 
             # ----- icon ----------------------------------------------------
             image = lv.image(app_cont)
@@ -113,7 +123,10 @@ class Launcher(Activity):
 
             # ----- events --------------------------------------------------
             app_cont.add_event_cb(lambda e, fullname=app.fullname: self._launch_app(fullname), lv.EVENT.CLICKED, None)
-            add_focus_highlight(app_cont)
+            if self._k10:
+                add_focus_highlight(app_cont, width=2)
+            else:
+                add_focus_highlight(app_cont)
 
             self._app_cont_map[app.fullname] = app_cont
 
@@ -127,7 +140,6 @@ class Launcher(Activity):
         self._focus_last_or_first()
 
     def _launch_app(self, fullname):
-        """Record which app was launched, show splash screen, then start it."""
         self._last_started_fullname = fullname
 
         # Uncomment to disable the splash screen display when starting an app:
@@ -187,9 +199,24 @@ class Launcher(Activity):
         self._cleanup_splash_screen()
         screen.set_scrollbar_mode(lv.SCROLLBAR_MODE.AUTO)
 
+    def _focus_first_usable_app(self):
+        for fullname, target in self._app_cont_map.items():
+            if fullname == "com.micropythonos.howto":
+                continue
+            if target:
+                lv.group_focus_obj(target)
+                return True
+        return False
+
     def _focus_last_or_first(self):
-        """Focus the last launched app tile if any."""
+        if self._k10 and self._last_started_fullname in (None, "com.micropythonos.howto"):
+            if self._focus_first_usable_app():
+                return
+
         target = self._app_cont_map.get(self._last_started_fullname)
         if target:
             lv.group_focus_obj(target)
+            return
 
+        if self._k10:
+            self._focus_first_usable_app()

--- a/internal_filesystem/builtin/apps/com.micropythonos.launcher/launcher.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.launcher/launcher.py
@@ -202,7 +202,7 @@ class Launcher(Activity):
     def _focus_first_usable_app(self):
         for fullname, target in self._app_cont_map.items():
             if fullname == "com.micropythonos.howto":
-                # K10 should resume on a launchable app instead of the startup HowTo.
+                # This K10-only fallback skips static HowTo and restores focus to another app.
                 continue
             if target:
                 lv.group_focus_obj(target)

--- a/internal_filesystem/lib/mpos/board/unihiker_k10.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10.py
@@ -21,7 +21,7 @@ import mpos.ui
 from machine import I2C, Pin
 from micropython import const
 from mpos import InputManager
-from mpos.board.unihiker_k10_input import K10ButtonInput
+from mpos.board.unihiker_k10_input import K10ButtonInput, create_expander_i2c
 
 # ── Display SPI pins ────────────────────────────────────────────────────────
 # K10 uses FSPI (SPI2, host=1) with CLK on GPIO12 (IO_MUX fast path)
@@ -60,25 +60,7 @@ BTNA_BIT    = const(0x10)  # P1.4: BTN_A input       (active-low)
 if __debug__: logger.debug("unihiker_k10.py: initializing XL9535 I2C expander")
 _i2c = None  # guarded: _keypad_read_cb catches AttributeError if init fails
 try:
-    _i2c = I2C(0, sda=Pin(I2C_SDA), scl=Pin(I2C_SCL), freq=400_000)
-
-    # Port 0: P0.0 = output (backlight), P0.1 = output (Camera_RST), P0.2 = input (BTN_B)
-    _cfg0 = _i2c.readfrom_mem(XL9535_ADDR, XL9535_CFG0, 1)[0]
-    _cfg0 &= ~BL_BIT       # P0.0 backlight: output
-    _cfg0 &= ~CAM_RST_BIT  # P0.1 Camera_RST: output
-    _cfg0 |=  BTNB_BIT     # P0.2 BTN_B: input
-    _i2c.writeto_mem(XL9535_ADDR, XL9535_CFG0, bytes([_cfg0]))
-
-    # Port 1: P1.4 = input (BTN_A)
-    _cfg1 = _i2c.readfrom_mem(XL9535_ADDR, XL9535_CFG1, 1)[0]
-    _cfg1 |= BTNA_BIT
-    _i2c.writeto_mem(XL9535_ADDR, XL9535_CFG1, bytes([_cfg1]))
-
-    # Turn backlight on (P0.0 high); release Camera_RST (P0.1 high = not in reset)
-    _out0 = _i2c.readfrom_mem(XL9535_ADDR, XL9535_OUT0, 1)[0]
-    _out0 |= BL_BIT | CAM_RST_BIT
-    _i2c.writeto_mem(XL9535_ADDR, XL9535_OUT0, bytes([_out0]))
-
+    _i2c = create_expander_i2c(I2C, Pin, I2C_SDA, I2C_SCL)
     if __debug__: logger.debug("unihiker_k10.py: XL9535 OK, backlight ON")
 except Exception as e:
     logger.error("unihiker_k10.py: XL9535 init failed: %s", e)
@@ -118,6 +100,7 @@ mpos.ui.main_display = ili9341.ILI9341(
 )
 # Type 2 = standard ILI9341 alternative init sequence (used by most SPI panels)
 mpos.ui.main_display.init(2)
+mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._180)
 mpos.ui.main_display.set_power(True)
 # Note: backlight is controlled via XL9535, not a GPIO pin — already turned on above
 
@@ -236,11 +219,21 @@ def _camera_reset():
         logger.error("unihiker_k10: camera_reset failed: %s", e)
 
 
+def _restore_expander_i2c():
+    global _i2c
+    try:
+        _i2c = create_expander_i2c(I2C, Pin, I2C_SDA, I2C_SCL)
+    except Exception as e:
+        _i2c = None
+        logger.error("unihiker_k10: XL9535 restore failed: %s", e)
+
+
 from mpos import CameraManager
 
 
 def init_cam(width, height, colormode):
     from camera import Camera, GrabMode, PixelFormat
+    _restore_expander_i2c()
     _camera_reset()
     frame_size = CameraManager.resolution_to_framesize(width, height)
     for attempt in range(3):
@@ -278,6 +271,7 @@ def deinit_cam(cam):
         logger.error("unihiker_k10: deinit_cam: %s", e)
     # SCCB leaves GPIO47/48 in an indeterminate state; brief pause lets I2C settle
     time.sleep_ms(20)
+    _restore_expander_i2c()
     _camera_reset()
 
 
@@ -288,9 +282,11 @@ def capture_cam(cam, colormode):
 def apply_cam_settings(cam, prefs):
     # GC2145 settings support; use generic OV helper as fallback
     try:
-        return CameraManager.ov_apply_camera_settings(cam, prefs)
+        result = CameraManager.ov_apply_camera_settings(cam, prefs)
     except Exception:
-        return None
+        result = None
+    _restore_expander_i2c()
+    return result
 
 
 CameraManager.add_camera(CameraManager.Camera(
@@ -301,6 +297,8 @@ CameraManager.add_camera(CameraManager.Camera(
     deinit=deinit_cam,
     capture=capture_cam,
     apply_settings=apply_cam_settings,
+    rgb565_byte_swap=True,
+    default_vflip=True,
 ))
 
 # ── On-board sensors (SC7A20H · LTR303ALS · AHT20) + RGB LEDs ────────────────

--- a/internal_filesystem/lib/mpos/board/unihiker_k10.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10.py
@@ -24,6 +24,7 @@ from mpos import InputManager
 from mpos.board.unihiker_k10_input import (
     K10ButtonInput,
     create_expander_i2c,
+    initialize_camera_with_recovery,
     is_direct_navigation_target,
 )
 from mpos.ui.focus import enable_focus_borders
@@ -260,32 +261,37 @@ def init_cam(width, height, colormode):
     _restore_expander_i2c()
     _camera_reset()
     frame_size = CameraManager.resolution_to_framesize(width, height)
-    for attempt in range(3):
-        try:
-            cam = Camera(
-                data_pins=[CAM_D2, CAM_D3, CAM_D4, CAM_D5,
-                           CAM_D6, CAM_D7, CAM_D8, CAM_D9],
-                vsync_pin=CAM_VSYNC,
-                href_pin=CAM_HREF,
-                sda_pin=I2C_SDA,
-                scl_pin=I2C_SCL,
-                pclk_pin=CAM_PCLK,
-                xclk_pin=CAM_XCLK,
-                xclk_freq=20_000_000,
-                powerdown_pin=-1,
-                reset_pin=-1,
-                pixel_format=PixelFormat.RGB565 if colormode else PixelFormat.GRAYSCALE,
-                frame_size=frame_size,
-                grab_mode=GrabMode.LATEST,
-                fb_count=1,
-            )
-            return cam
-        except Exception as e:
-            if attempt < 2:
-                logger.error("unihiker_k10: init_cam attempt %d failed: %s", attempt, e)
-            else:
-                logger.error("unihiker_k10: init_cam failed after 3 attempts: %s", e)
-    return None
+
+    def create_camera():
+        return Camera(
+            data_pins=[CAM_D2, CAM_D3, CAM_D4, CAM_D5,
+                       CAM_D6, CAM_D7, CAM_D8, CAM_D9],
+            vsync_pin=CAM_VSYNC,
+            href_pin=CAM_HREF,
+            sda_pin=I2C_SDA,
+            scl_pin=I2C_SCL,
+            pclk_pin=CAM_PCLK,
+            xclk_pin=CAM_XCLK,
+            xclk_freq=20_000_000,
+            powerdown_pin=-1,
+            reset_pin=-1,
+            pixel_format=PixelFormat.RGB565 if colormode else PixelFormat.GRAYSCALE,
+            frame_size=frame_size,
+            grab_mode=GrabMode.LATEST,
+            fb_count=1,
+        )
+
+    def log_init_failure(attempt, error):
+        if attempt < 2:
+            logger.error("unihiker_k10: init_cam attempt %d failed: %s", attempt, error)
+        else:
+            logger.error("unihiker_k10: init_cam failed after 3 attempts: %s", error)
+
+    return initialize_camera_with_recovery(
+        create_camera,
+        log_init_failure,
+        _restore_expander_i2c,
+    )
 
 
 def deinit_cam(cam):

--- a/internal_filesystem/lib/mpos/board/unihiker_k10.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10.py
@@ -101,10 +101,12 @@ mpos.ui.main_display = ili9341.ILI9341(
     display_height=TFT_HEIGHT,
     color_space=lv.COLOR_FORMAT.RGB565,
     color_byte_order=ili9341.BYTE_ORDER_BGR,
+    # The K10 panel expects swapped RGB565 bytes on its SPI bus.
     rgb565_byte_swap=True,
 )
 # Type 2 = standard ILI9341 alternative init sequence (used by most SPI panels)
 mpos.ui.main_display.init(2)
+# The LCD is mounted upside down relative to the K10 enclosure orientation.
 mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._180)
 mpos.ui.main_display.set_power(True)
 # Note: backlight is controlled via XL9535, not a GPIO pin — already turned on above
@@ -241,6 +243,7 @@ def _camera_reset():
 
 
 def _restore_expander_i2c():
+    # Camera SCCB shares GPIO47/48 and leaves the keypad expander bus unusable.
     global _i2c
     try:
         _i2c = create_expander_i2c(I2C, Pin, I2C_SDA, I2C_SCL)
@@ -318,6 +321,7 @@ CameraManager.add_camera(CameraManager.Camera(
     deinit=deinit_cam,
     capture=capture_cam,
     apply_settings=apply_cam_settings,
+    # GC2145 frames are byte-swapped; the physical camera orientation needs vflip.
     rgb565_byte_swap=True,
     default_vflip=True,
 ))

--- a/internal_filesystem/lib/mpos/board/unihiker_k10.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10.py
@@ -21,6 +21,7 @@ import mpos.ui
 from machine import I2C, Pin
 from micropython import const
 from mpos import InputManager
+from mpos.board.unihiker_k10_input import K10ButtonInput
 
 # ── Display SPI pins ────────────────────────────────────────────────────────
 # K10 uses FSPI (SPI2, host=1) with CLK on GPIO12 (IO_MUX fast path)
@@ -124,6 +125,7 @@ mpos.ui.main_display.set_power(True)
 # BTN_B: NEXT  — cycles through focusable items; repeats while held
 # BTN_A: ENTER — selects / confirms the focused item
 _last_key = None
+_button_input = K10ButtonInput(ticks_diff=time.ticks_diff)
 
 
 def _keypad_read_cb(indev, data):
@@ -135,24 +137,44 @@ def _keypad_read_cb(indev, data):
         btn_a = not bool(p1 & BTNA_BIT)  # P1.4, active-low
         btn_b = not bool(p0 & BTNB_BIT)  # P0.2, active-low
     except Exception:
-        btn_a = False
-        btn_b = False
+        current_key = _button_input.cancel()
+        data.key = {
+            "next": lv.KEY.NEXT,
+            "right": lv.KEY.RIGHT,
+        }.get(current_key, lv.KEY.ENTER)
+        data.state = lv.INDEV_STATE.RELEASED
+        _last_key = None
+        return
 
-    if btn_a:
-        current_key = lv.KEY.ENTER
-    elif btn_b:
-        current_key = lv.KEY.NEXT
-    else:
-        current_key = None
+    focusgroup = lv.group_get_default()
+    focused = focusgroup.get_focused() if focusgroup else None
+    keyboard_focused = isinstance(focused, lv.keyboard) or isinstance(focused, lv.buttonmatrix)
+    if keyboard_focused:
+        focused.add_state(lv.STATE.FOCUS_KEY)
+    action, pressed, back = _button_input.update(
+        btn_a,
+        btn_b,
+        time.ticks_ms(),
+        keyboard_focused,
+    )
 
+    if back:
+        mpos.ui.back_screen()
+
+    current_key = {
+        "enter": lv.KEY.ENTER,
+        "next": lv.KEY.NEXT,
+        "right": lv.KEY.RIGHT,
+    }.get(action)
     if current_key is None:
         data.key = _last_key if _last_key else lv.KEY.ENTER
         data.state = lv.INDEV_STATE.RELEASED
         _last_key = None
-    else:
-        data.key = current_key
-        data.state = lv.INDEV_STATE.PRESSED
-        _last_key = current_key
+        return
+
+    data.key = current_key
+    data.state = lv.INDEV_STATE.PRESSED if pressed else lv.INDEV_STATE.RELEASED
+    _last_key = current_key if pressed else None
 
 
 indev = lv.indev_create()

--- a/internal_filesystem/lib/mpos/board/unihiker_k10.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10.py
@@ -21,7 +21,12 @@ import mpos.ui
 from machine import I2C, Pin
 from micropython import const
 from mpos import InputManager
-from mpos.board.unihiker_k10_input import K10ButtonInput, create_expander_i2c
+from mpos.board.unihiker_k10_input import (
+    K10ButtonInput,
+    create_expander_i2c,
+    is_direct_navigation_target,
+)
+from mpos.ui.focus import enable_focus_borders
 
 # ── Display SPI pins ────────────────────────────────────────────────────────
 # K10 uses FSPI (SPI2, host=1) with CLK on GPIO12 (IO_MUX fast path)
@@ -105,8 +110,8 @@ mpos.ui.main_display.set_power(True)
 # Note: backlight is controlled via XL9535, not a GPIO pin — already turned on above
 
 # ── Button input (keypad indev) ───────────────────────────────────────────────
-# BTN_B: NEXT  — cycles through focusable items; repeats while held
-# BTN_A: ENTER — selects / confirms the focused item
+# BTN_B: NEXT — cycles through focusable items; an open dropdown uses tap/hold for next/previous
+# BTN_A: ENTER — selects / confirms the focused item; holding it cancels an open dropdown or goes back
 _last_key = None
 _button_input = K10ButtonInput(ticks_diff=time.ticks_diff)
 
@@ -124,7 +129,9 @@ def _keypad_read_cb(indev, data):
         data.key = {
             "next": lv.KEY.NEXT,
             "right": lv.KEY.RIGHT,
-        }.get(current_key, lv.KEY.ENTER)
+            "left": lv.KEY.LEFT,
+            "esc": lv.KEY.ESC,
+        }.get(current_key, _last_key or lv.KEY.ENTER)
         data.state = lv.INDEV_STATE.RELEASED
         _last_key = None
         return
@@ -132,22 +139,36 @@ def _keypad_read_cb(indev, data):
     focusgroup = lv.group_get_default()
     focused = focusgroup.get_focused() if focusgroup else None
     keyboard_focused = isinstance(focused, lv.keyboard) or isinstance(focused, lv.buttonmatrix)
+    dropdown_open = isinstance(focused, lv.dropdown)
+    if dropdown_open:
+        try:
+            dropdown_open = focused.is_open()
+        except Exception:
+            dropdown_open = False
+    direct_navigation_focused = is_direct_navigation_target(
+        focused, lv.keyboard, lv.buttonmatrix, lv.dropdown
+    )
     if keyboard_focused:
         focused.add_state(lv.STATE.FOCUS_KEY)
     action, pressed, back = _button_input.update(
         btn_a,
         btn_b,
         time.ticks_ms(),
-        keyboard_focused,
+        direct_navigation_focused,
+        dropdown_open,
     )
 
     if back:
         mpos.ui.back_screen()
+    if action in ("next", "right", "left") and pressed:
+        enable_focus_borders()
 
     current_key = {
         "enter": lv.KEY.ENTER,
         "next": lv.KEY.NEXT,
         "right": lv.KEY.RIGHT,
+        "left": lv.KEY.LEFT,
+        "esc": lv.KEY.ESC,
     }.get(action)
     if current_key is None:
         data.key = _last_key if _last_key else lv.KEY.ENTER

--- a/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
@@ -1,0 +1,60 @@
+class K10ButtonInput:
+    def __init__(self, long_press_ms=700, ticks_diff=None):
+        self._long_press_ms = long_press_ms
+        self._ticks_diff = ticks_diff or (lambda current, previous: current - previous)
+        self._a_pressed = False
+        self._a_down_at = None
+        self._a_back_fired = False
+        self._active_b_key = None
+        self._events = []
+
+    def update(self, a_pressed, b_pressed, now_ms, keyboard_focused):
+        if a_pressed and not self._a_pressed:
+            self._a_down_at = now_ms
+            self._a_back_fired = False
+            self._release_b()
+
+        if a_pressed and self._a_down_at is not None and not self._a_back_fired:
+            if self._ticks_diff(now_ms, self._a_down_at) >= self._long_press_ms:
+                self._a_back_fired = True
+                self._events.append((None, False, True))
+
+        if not a_pressed and self._a_pressed:
+            if not self._a_back_fired:
+                self._events.append(("enter", True, False))
+                self._events.append(("enter", False, False))
+            self._a_down_at = None
+            self._a_back_fired = False
+
+        if a_pressed:
+            self._release_b()
+        elif b_pressed:
+            desired_key = "right" if keyboard_focused else "next"
+            if self._active_b_key != desired_key:
+                self._release_b()
+                self._active_b_key = desired_key
+                self._events.append((desired_key, True, False))
+        else:
+            self._release_b()
+
+        self._a_pressed = a_pressed
+
+        if self._events:
+            return self._events.pop(0)
+        if self._active_b_key is not None:
+            return self._active_b_key, True, False
+        return None, False, False
+
+    def cancel(self):
+        active_key = self._active_b_key
+        self._a_pressed = False
+        self._a_down_at = None
+        self._a_back_fired = False
+        self._active_b_key = None
+        self._events = []
+        return active_key
+
+    def _release_b(self):
+        if self._active_b_key is not None:
+            self._events.append((self._active_b_key, False, False))
+            self._active_b_key = None

--- a/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
@@ -10,6 +10,15 @@ def create_expander_i2c(i2c_class, pin_class, sda, scl):
     return i2c
 
 
+def is_direct_navigation_target(focused, keyboard_type, buttonmatrix_type, dropdown_type):
+    if isinstance(focused, dropdown_type):
+        try:
+            return focused.is_open()
+        except Exception:
+            return False
+    return isinstance(focused, keyboard_type) or isinstance(focused, buttonmatrix_type)
+
+
 class K10ButtonInput:
     def __init__(self, long_press_ms=700, ticks_diff=None):
         self._long_press_ms = long_press_ms
@@ -18,18 +27,26 @@ class K10ButtonInput:
         self._a_down_at = None
         self._a_back_fired = False
         self._active_b_key = None
+        self._b_dropdown_pressed = False
+        self._b_down_at = None
+        self._b_previous_fired = False
         self._events = []
 
-    def update(self, a_pressed, b_pressed, now_ms, keyboard_focused):
+    def update(self, a_pressed, b_pressed, now_ms, direct_navigation_focused, dropdown_open=False):
         if a_pressed and not self._a_pressed:
             self._a_down_at = now_ms
             self._a_back_fired = False
-            self._release_b()
+            self._cancel_b()
 
         if a_pressed and self._a_down_at is not None and not self._a_back_fired:
             if self._ticks_diff(now_ms, self._a_down_at) >= self._long_press_ms:
                 self._a_back_fired = True
-                self._events.append((None, False, True))
+                if dropdown_open:
+                    # ESC preserves LVGL's unconfirmed dropdown selection and stays in the app.
+                    self._events.append(("esc", True, False))
+                    self._events.append(("esc", False, False))
+                else:
+                    self._events.append((None, False, True))
 
         if not a_pressed and self._a_pressed:
             if not self._a_back_fired:
@@ -39,15 +56,12 @@ class K10ButtonInput:
             self._a_back_fired = False
 
         if a_pressed:
-            self._release_b()
-        elif b_pressed:
-            desired_key = "right" if keyboard_focused else "next"
-            if self._active_b_key != desired_key:
-                self._release_b()
-                self._active_b_key = desired_key
-                self._events.append((desired_key, True, False))
+            self._cancel_b()
+        elif dropdown_open:
+            self._update_dropdown_b(b_pressed, now_ms)
         else:
-            self._release_b()
+            self._cancel_dropdown_b()
+            self._update_navigation_b(b_pressed, direct_navigation_focused)
 
         self._a_pressed = a_pressed
 
@@ -63,8 +77,47 @@ class K10ButtonInput:
         self._a_down_at = None
         self._a_back_fired = False
         self._active_b_key = None
+        self._b_dropdown_pressed = False
+        self._b_down_at = None
+        self._b_previous_fired = False
         self._events = []
         return active_key
+
+    def _update_dropdown_b(self, b_pressed, now_ms):
+        # Delay B's action until release so a long press can use the same key for previous.
+        if b_pressed and not self._b_dropdown_pressed:
+            self._b_dropdown_pressed = True
+            self._b_down_at = now_ms
+            self._b_previous_fired = False
+        elif b_pressed and not self._b_previous_fired:
+            if self._ticks_diff(now_ms, self._b_down_at) >= self._long_press_ms:
+                self._b_previous_fired = True
+                self._events.append(("left", True, False))
+                self._events.append(("left", False, False))
+        elif not b_pressed and self._b_dropdown_pressed:
+            if not self._b_previous_fired:
+                self._events.append(("right", True, False))
+                self._events.append(("right", False, False))
+            self._cancel_dropdown_b()
+
+    def _update_navigation_b(self, b_pressed, direct_navigation_focused):
+        if b_pressed:
+            desired_key = "right" if direct_navigation_focused else "next"
+            if self._active_b_key != desired_key:
+                self._release_b()
+                self._active_b_key = desired_key
+                self._events.append((desired_key, True, False))
+        else:
+            self._release_b()
+
+    def _cancel_b(self):
+        self._release_b()
+        self._cancel_dropdown_b()
+
+    def _cancel_dropdown_b(self):
+        self._b_dropdown_pressed = False
+        self._b_down_at = None
+        self._b_previous_fired = False
 
     def _release_b(self):
         if self._active_b_key is not None:

--- a/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
@@ -1,4 +1,6 @@
 def create_expander_i2c(i2c_class, pin_class, sda, scl):
+    # Camera SCCB can reconfigure I2C(0); restore the XL9535 after camera use.
+    # P0.0/P0.1 are outputs, while P0.2/P1.4 return to BTN_B/BTN_A inputs.
     i2c = i2c_class(0, sda=pin_class(sda), scl=pin_class(scl), freq=400_000)
     cfg0 = i2c.readfrom_mem(0x20, 0x06, 1)[0]
     cfg0 = (cfg0 & ~0x03) | 0x04
@@ -11,6 +13,7 @@ def create_expander_i2c(i2c_class, pin_class, sda, scl):
 
 
 def is_direct_navigation_target(focused, keyboard_type, buttonmatrix_type, dropdown_type):
+    # A closed dropdown is one focus target; its open list needs direct navigation.
     if isinstance(focused, dropdown_type):
         try:
             return focused.is_open()

--- a/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
@@ -1,3 +1,15 @@
+def create_expander_i2c(i2c_class, pin_class, sda, scl):
+    i2c = i2c_class(0, sda=pin_class(sda), scl=pin_class(scl), freq=400_000)
+    cfg0 = i2c.readfrom_mem(0x20, 0x06, 1)[0]
+    cfg0 = (cfg0 & ~0x03) | 0x04
+    i2c.writeto_mem(0x20, 0x06, bytes([cfg0]))
+    cfg1 = i2c.readfrom_mem(0x20, 0x07, 1)[0] | 0x10
+    i2c.writeto_mem(0x20, 0x07, bytes([cfg1]))
+    out0 = i2c.readfrom_mem(0x20, 0x02, 1)[0] | 0x03
+    i2c.writeto_mem(0x20, 0x02, bytes([out0]))
+    return i2c
+
+
 class K10ButtonInput:
     def __init__(self, long_press_ms=700, ticks_diff=None):
         self._long_press_ms = long_press_ms

--- a/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
+++ b/internal_filesystem/lib/mpos/board/unihiker_k10_input.py
@@ -22,6 +22,16 @@ def is_direct_navigation_target(focused, keyboard_type, buttonmatrix_type, dropd
     return isinstance(focused, keyboard_type) or isinstance(focused, buttonmatrix_type)
 
 
+def initialize_camera_with_recovery(init_camera, on_failure, restore_expander_i2c, attempts=3):
+    for attempt in range(attempts):
+        try:
+            return init_camera()
+        except Exception as error:
+            on_failure(attempt, error)
+    restore_expander_i2c()
+    return None
+
+
 class K10ButtonInput:
     def __init__(self, long_press_ms=700, ticks_diff=None):
         self._long_press_ms = long_press_ms

--- a/internal_filesystem/lib/mpos/camera_manager.py
+++ b/internal_filesystem/lib/mpos/camera_manager.py
@@ -40,7 +40,7 @@ class Camera:
     Represents a camera device with its characteristics.
     """
 
-    def __init__(self, lens_facing, name=None, vendor=None, version=None, init=None, deinit=None, capture=None, apply_settings=None, rotation_degrees=0):
+    def __init__(self, lens_facing, name=None, vendor=None, version=None, init=None, deinit=None, capture=None, apply_settings=None, rotation_degrees=0, rgb565_byte_swap=False, default_vflip=True):
         """Initialize camera metadata.
 
         Args:
@@ -59,6 +59,8 @@ class Camera:
         self.capture_function = capture
         self.apply_settings_function = apply_settings
         self.rotation_degrees = rotation_degrees
+        self.rgb565_byte_swap = rgb565_byte_swap
+        self.default_vflip = default_vflip
 
     def __repr__(self):
         facing_names = {
@@ -87,6 +89,12 @@ class Camera:
 
     def get_rotation_degrees(self):
         return self.rotation_degrees
+
+    def get_rgb565_byte_swap(self):
+        return self.rgb565_byte_swap
+
+    def get_default_vflip(self):
+        return self.default_vflip
 
 
 class CameraManager:

--- a/internal_filesystem/lib/mpos/camera_manager.py
+++ b/internal_filesystem/lib/mpos/camera_manager.py
@@ -49,6 +49,8 @@ class Camera:
             vendor: Camera vendor/manufacturer (e.g., "OmniVision")
             version: Driver version (default 1)
             rotation_degrees: how many degrees the camera is rotated clockwise
+            rgb565_byte_swap: Whether color frames use byte-swapped RGB565 data.
+            default_vflip: Default vertical flip for newly created camera preferences.
         """
         self.lens_facing = lens_facing
         self.name = name or "Camera"

--- a/internal_filesystem/lib/mpos/ui/camera_activity.py
+++ b/internal_filesystem/lib/mpos/ui/camera_activity.py
@@ -8,6 +8,7 @@ import time
 from ..time import epoch_seconds
 from .camera_settings import CameraSettingsActivity
 from ..camera_manager import CameraManager
+from ..device_info import DeviceInfo
 from .. import ui as mpos_ui
 from ..app.activity import Activity
 
@@ -158,6 +159,9 @@ class CameraActivity(Activity):
         self.snap_button.set_style_radius(self.button_width, lv.PART.MAIN)
 
     def _add_focusable_buttons(self):
+        # K10 has only A and B, so give camera controls visible focus and a stable start.
+        if DeviceInfo.get_hardware_id() != "unihiker_k10":
+            return
         for button in (
             self.close_button,
             self.settings_button,

--- a/internal_filesystem/lib/mpos/ui/camera_activity.py
+++ b/internal_filesystem/lib/mpos/ui/camera_activity.py
@@ -167,6 +167,7 @@ class CameraActivity(Activity):
             mpos_ui.add_focus_highlight(button, width=2)
         lv.group_focus_obj(self.close_button)
 
+    # Merge common, mode-specific, and board-specific camera defaults.
     def _get_camera_defaults(self, mode_defaults):
         defaults = {}
         defaults.update(CameraSettingsActivity.COMMON_DEFAULTS)

--- a/internal_filesystem/lib/mpos/ui/camera_activity.py
+++ b/internal_filesystem/lib/mpos/ui/camera_activity.py
@@ -87,6 +87,7 @@ class CameraActivity(Activity):
         snap_label = lv.label(self.snap_button)
         snap_label.set_text(lv.SYMBOL.OK)
         snap_label.center()
+        self._add_focusable_buttons()
 
         self.status_label_cont = lv.obj(self.main_screen)
         self.status_label_cont.set_style_bg_color(lv.color_white(), lv.PART.MAIN)
@@ -156,6 +157,23 @@ class CameraActivity(Activity):
         self.qr_button.set_size(self.button_width, self.button_height)
         self.snap_button.set_style_radius(self.button_width, lv.PART.MAIN)
 
+    def _add_focusable_buttons(self):
+        for button in (
+            self.close_button,
+            self.settings_button,
+            self.qr_button,
+            self.snap_button,
+        ):
+            mpos_ui.add_focus_highlight(button, width=2)
+        lv.group_focus_obj(self.close_button)
+
+    def _get_camera_defaults(self, mode_defaults):
+        defaults = {}
+        defaults.update(CameraSettingsActivity.COMMON_DEFAULTS)
+        defaults.update(mode_defaults)
+        defaults["vflip"] = CameraManager.get_cameras()[0].get_default_vflip()
+        return defaults
+
     def start_cam(self):
         # Init camera:
         firstcam = CameraManager.get_cameras()[0]
@@ -184,10 +202,7 @@ class CameraActivity(Activity):
         if self.scanqr_mode:
             if __debug__: logger.debug("loading scanqr settings...")
             if not self.scanqr_prefs:
-                # Merge common and scanqr-specific defaults
-                scanqr_defaults = {}
-                scanqr_defaults.update(CameraSettingsActivity.COMMON_DEFAULTS)
-                scanqr_defaults.update(CameraSettingsActivity.SCANQR_DEFAULTS)
+                scanqr_defaults = self._get_camera_defaults(CameraSettingsActivity.SCANQR_DEFAULTS)
                 self.scanqr_prefs = SharedPreferences(
                     self.appFullName,
                     filename=self.SCANQR_CONFIG,
@@ -199,10 +214,7 @@ class CameraActivity(Activity):
             self.colormode = self.scanqr_prefs.get_bool("colormode")
         else:
             if not self.prefs:
-                # Merge common and normal-specific defaults
-                normal_defaults = {}
-                normal_defaults.update(CameraSettingsActivity.COMMON_DEFAULTS)
-                normal_defaults.update(CameraSettingsActivity.NORMAL_DEFAULTS)
+                normal_defaults = self._get_camera_defaults(CameraSettingsActivity.NORMAL_DEFAULTS)
                 self.prefs = SharedPreferences(self.appFullName, defaults=normal_defaults)
             # Defaults come from constructor, no need to pass them here
             self.width = self.prefs.get_int("resolution_width")
@@ -210,13 +222,20 @@ class CameraActivity(Activity):
             self.colormode = self.prefs.get_bool("colormode")
 
     def update_preview_image(self):
+        color_format = lv.COLOR_FORMAT.L8
+        if self.colormode:
+            firstcam = CameraManager.get_cameras()[0]
+            if firstcam.get_rgb565_byte_swap():
+                color_format = lv.COLOR_FORMAT.RGB565_SWAPPED
+            else:
+                color_format = lv.COLOR_FORMAT.RGB565
         self.image_dsc = lv.image_dsc_t({
             "header": {
                 "magic": lv.IMAGE_HEADER_MAGIC,
                 "w": self.width,
                 "h": self.height,
                 "stride": self.width * (2 if self.colormode else 1),
-                "cf": lv.COLOR_FORMAT.RGB565 if self.colormode else lv.COLOR_FORMAT.L8
+                "cf": color_format
             },
             'data_size': self.width * self.height * (2 if self.colormode else 1),
             'data': None # Will be updated per frame

--- a/tests/test_camera_manager.py
+++ b/tests/test_camera_manager.py
@@ -30,6 +30,22 @@ class TestCameraClass(unittest.TestCase):
         self.assertEqual(cam.name, "Camera")
         self.assertEqual(cam.vendor, "Unknown")
         self.assertEqual(cam.version, 1)
+        self.assertFalse(cam.get_rgb565_byte_swap())
+        self.assertTrue(cam.get_default_vflip())
+
+    def test_camera_rgb565_byte_swap(self):
+        cam = CameraManager.Camera(
+            lens_facing=CameraManager.CameraCharacteristics.LENS_FACING_FRONT,
+            rgb565_byte_swap=True
+        )
+        self.assertTrue(cam.get_rgb565_byte_swap())
+
+    def test_camera_default_vflip(self):
+        cam = CameraManager.Camera(
+            lens_facing=CameraManager.CameraCharacteristics.LENS_FACING_FRONT,
+            default_vflip=False
+        )
+        self.assertFalse(cam.get_default_vflip())
 
     def test_camera_repr(self):
         """Test Camera __repr__ method."""
@@ -295,4 +311,3 @@ class TestCameraManagerUsagePattern(unittest.TestCase):
             has_camera = False
         
         self.assertFalse(has_camera)
-

--- a/tests/test_graphical_appstore_focus.py
+++ b/tests/test_graphical_appstore_focus.py
@@ -145,6 +145,54 @@ class TestAppStoreFocus(unittest.TestCase):
             "to the small corner button.",
         )
 
+    def test_dropdown_confirmation_allows_focus_to_leave(self):
+        activity = _get_appstore_activity()
+        dropdown = activity.category_dropdown
+        group = lv.group_get_default()
+
+        activity._category_options = ["One", "Two", "Three"]
+        dropdown.set_options("One\nTwo\nThree")
+        dropdown.set_selected(0)
+        lv.group_focus_obj(dropdown)
+
+        self.assertFalse(dropdown.is_open())
+        group.send_data(lv.KEY.ENTER)
+        self.assertTrue(dropdown.is_open())
+        group.send_data(lv.KEY.RIGHT)
+        self.assertEqual(dropdown.get_selected(), 1)
+        group.send_data(lv.KEY.ENTER)
+        self.assertFalse(dropdown.is_open())
+        group.focus_next()
+        self.assertIsNot(_focused_obj(), dropdown)
+
+    def test_dropdown_escape_restores_unconfirmed_category(self):
+        activity = _get_appstore_activity()
+        dropdown = activity.category_dropdown
+        group = lv.group_get_default()
+        rebuilds = []
+        original_create_apps_list = activity.create_apps_list
+
+        activity._category_options = ["One", "Two", "Three"]
+        dropdown.set_options("One\nTwo\nThree")
+        dropdown.set_selected(0)
+        activity.create_apps_list = lambda: rebuilds.append(dropdown.get_selected())
+        lv.group_focus_obj(dropdown)
+
+        try:
+            group.send_data(lv.KEY.ENTER)
+            group.send_data(lv.KEY.RIGHT)
+            self.assertEqual(dropdown.get_selected(), 1)
+            group.send_data(lv.KEY.LEFT)
+            self.assertEqual(dropdown.get_selected(), 0)
+            group.send_data(lv.KEY.RIGHT)
+            self.assertEqual(dropdown.get_selected(), 1)
+            group.send_data(lv.KEY.ESC)
+            self.assertFalse(dropdown.is_open())
+            self.assertEqual(dropdown.get_selected(), 0)
+            self.assertEqual(rebuilds, [])
+        finally:
+            activity.create_apps_list = original_create_apps_list
+
     def test_update_all_button_reachable_when_visible(self):
         """When 'Update N App(s)' is visible it must be reachable via DOWN from settings_button."""
         activity = _get_appstore_activity()

--- a/tests/test_graphical_camera_color_format.py
+++ b/tests/test_graphical_camera_color_format.py
@@ -2,7 +2,7 @@ import unittest
 
 import lvgl as lv
 
-from mpos import CameraManager
+from mpos import CameraManager, DeviceInfo
 from mpos.ui.camera_activity import CameraActivity
 from mpos.ui.camera_settings import CameraSettingsActivity
 
@@ -10,9 +10,11 @@ from mpos.ui.camera_settings import CameraSettingsActivity
 class TestCameraColorFormat(unittest.TestCase):
     def setUp(self):
         self.cameras = CameraManager._cameras
+        self.hardware_id = DeviceInfo.get_hardware_id()
 
     def tearDown(self):
         CameraManager._cameras = self.cameras
+        DeviceInfo.set_hardware_id(self.hardware_id)
 
     def make_activity(self, rgb565_byte_swap):
         CameraManager._cameras = [
@@ -51,18 +53,33 @@ class TestCameraColorFormat(unittest.TestCase):
         defaults = activity._get_camera_defaults(CameraSettingsActivity.NORMAL_DEFAULTS)
         self.assertFalse(defaults["vflip"])
 
-    def test_camera_buttons_are_added_to_focus_group(self):
+    def test_k10_camera_buttons_start_with_close_focused(self):
         group = lv.group_get_default()
         group.remove_all_objs()
+        DeviceInfo.set_hardware_id("unihiker_k10")
         activity = CameraActivity()
         activity.main_screen = lv.obj()
         activity.close_button = lv.button(activity.main_screen)
         activity.settings_button = lv.button(activity.main_screen)
         activity.qr_button = lv.button(activity.main_screen)
         activity.snap_button = lv.button(activity.main_screen)
+        lv.group_focus_obj(activity.settings_button)
         activity._add_focusable_buttons()
-        self.assertEqual(group.get_obj_count(), 4)
         self.assertTrue(group.get_focused() is activity.close_button)
+
+    def test_non_k10_camera_buttons_keep_existing_focus(self):
+        group = lv.group_get_default()
+        group.remove_all_objs()
+        DeviceInfo.set_hardware_id("desktop")
+        activity = CameraActivity()
+        activity.main_screen = lv.obj()
+        activity.close_button = lv.button(activity.main_screen)
+        activity.settings_button = lv.button(activity.main_screen)
+        activity.qr_button = lv.button(activity.main_screen)
+        activity.snap_button = lv.button(activity.main_screen)
+        lv.group_focus_obj(activity.settings_button)
+        activity._add_focusable_buttons()
+        self.assertTrue(group.get_focused() is activity.settings_button)
 
 
 if __name__ == "__main__":

--- a/tests/test_graphical_camera_color_format.py
+++ b/tests/test_graphical_camera_color_format.py
@@ -1,0 +1,69 @@
+import unittest
+
+import lvgl as lv
+
+from mpos import CameraManager
+from mpos.ui.camera_activity import CameraActivity
+from mpos.ui.camera_settings import CameraSettingsActivity
+
+
+class TestCameraColorFormat(unittest.TestCase):
+    def setUp(self):
+        self.cameras = CameraManager._cameras
+
+    def tearDown(self):
+        CameraManager._cameras = self.cameras
+
+    def make_activity(self, rgb565_byte_swap):
+        CameraManager._cameras = [
+            CameraManager.Camera(
+                lens_facing=CameraManager.CameraCharacteristics.LENS_FACING_FRONT,
+                rgb565_byte_swap=rgb565_byte_swap,
+            )
+        ]
+        activity = CameraActivity()
+        activity.image = lv.image(lv.screen_active())
+        activity.width = 240
+        activity.height = 240
+        activity.colormode = True
+        activity.update_preview_image()
+        return activity
+
+    def test_default_camera_uses_rgb565(self):
+        activity = self.make_activity(False)
+        self.assertEqual(activity.image_dsc.header.cf, lv.COLOR_FORMAT.RGB565)
+
+    def test_swapped_camera_uses_rgb565_swapped(self):
+        activity = self.make_activity(True)
+        self.assertEqual(
+            activity.image_dsc.header.cf,
+            lv.COLOR_FORMAT.RGB565_SWAPPED,
+        )
+
+    def test_camera_defaults_use_camera_vflip(self):
+        CameraManager._cameras = [
+            CameraManager.Camera(
+                lens_facing=CameraManager.CameraCharacteristics.LENS_FACING_FRONT,
+                default_vflip=False,
+            )
+        ]
+        activity = CameraActivity()
+        defaults = activity._get_camera_defaults(CameraSettingsActivity.NORMAL_DEFAULTS)
+        self.assertFalse(defaults["vflip"])
+
+    def test_camera_buttons_are_added_to_focus_group(self):
+        group = lv.group_get_default()
+        group.remove_all_objs()
+        activity = CameraActivity()
+        activity.main_screen = lv.obj()
+        activity.close_button = lv.button(activity.main_screen)
+        activity.settings_button = lv.button(activity.main_screen)
+        activity.qr_button = lv.button(activity.main_screen)
+        activity.snap_button = lv.button(activity.main_screen)
+        activity._add_focusable_buttons()
+        self.assertEqual(group.get_obj_count(), 4)
+        self.assertTrue(group.get_focused() is activity.close_button)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graphical_howto_app.py
+++ b/tests/test_graphical_howto_app.py
@@ -15,6 +15,7 @@ import lvgl as lv
 import mpos.ui
 from mpos import (
     AppManager,
+    DeviceInfo,
     wait_for_text,
     retry_action_until,
     find_label_with_text,
@@ -226,3 +227,43 @@ class TestHowToAppFocusNavigation(unittest.TestCase):
             f"HowTo should not be the foreground app after closing. "
             f"Got: {foreground}",
         )
+
+
+class TestHowToAppK10FocusNavigation(unittest.TestCase):
+    def setUp(self):
+        self._hardware_id = DeviceInfo.get_hardware_id()
+        _go_back_to_launcher()
+        DeviceInfo.set_hardware_id("unihiker_k10")
+
+        result = AppManager.start_app("com.micropythonos.howto")
+        self.assertTrue(result, "HowTo app failed to launch")
+        self.assertTrue(
+            wait_for_text("B: next. Hold B in a list: previous.", timeout=10),
+            "K10 HowTo instructions did not load within timeout",
+        )
+        _wait_ms(200)
+
+    def tearDown(self):
+        try:
+            checkbox = _find_checkbox(lv.screen_active())
+            if checkbox:
+                checkbox.add_state(lv.STATE.CHECKED)
+            _go_back_to_launcher()
+        finally:
+            DeviceInfo.set_hardware_id(self._hardware_id)
+
+    def test_k10_keeps_static_help_out_of_the_focus_cycle(self):
+        screen = lv.screen_active()
+        checkbox = _find_checkbox(screen)
+        close_button = find_button_with_text(screen, "Close")
+        group = lv.group_get_default()
+
+        self.assertIsNotNone(checkbox, "Could not find checkbox in K10 HowTo")
+        self.assertIsNotNone(close_button, "Could not find Close button in K10 HowTo")
+        self.assertIsNotNone(group, "No default focus group")
+        self.assertIs(
+            _focused_obj(),
+            close_button,
+            "K10 HowTo should focus Close so the two-button user can exit immediately",
+        )
+        self.assertEqual(group.get_obj_count(), 2)

--- a/tests/test_graphical_howto_app.py
+++ b/tests/test_graphical_howto_app.py
@@ -238,7 +238,7 @@ class TestHowToAppK10FocusNavigation(unittest.TestCase):
         result = AppManager.start_app("com.micropythonos.howto")
         self.assertTrue(result, "HowTo app failed to launch")
         self.assertTrue(
-            wait_for_text("B: next. Hold B in a list: previous.", timeout=10),
+            wait_for_text("Open a drop-down: B next. Hold B: previous.", timeout=10),
             "K10 HowTo instructions did not load within timeout",
         )
         _wait_ms(200)

--- a/tests/test_unihiker_k10_input.py
+++ b/tests/test_unihiker_k10_input.py
@@ -3,6 +3,7 @@ import unittest
 from mpos.board.unihiker_k10_input import (
     K10ButtonInput,
     create_expander_i2c,
+    initialize_camera_with_recovery,
     is_direct_navigation_target,
 )
 
@@ -145,6 +146,51 @@ class TestK10ButtonInput(unittest.TestCase):
         self.assertEqual(self.input.update(True, True, 120, False), ("next", False, False))
         self.assertEqual(self.input.update(False, False, 200, False), ("enter", True, False))
         self.assertEqual(self.input.update(False, False, 220, False), ("enter", False, False))
+
+
+class TestK10CameraInitialization(unittest.TestCase):
+    def test_all_failed_attempts_restore_expander_i2c(self):
+        attempts = []
+        failures = []
+        recoveries = []
+
+        def init_camera():
+            attempts.append(True)
+            raise OSError("camera unavailable")
+
+        result = initialize_camera_with_recovery(
+            init_camera,
+            lambda attempt, error: failures.append(attempt),
+            lambda: recoveries.append(True),
+        )
+
+        self.assertTrue(result is None)
+        self.assertEqual(len(attempts), 3)
+        self.assertEqual(failures, [0, 1, 2])
+        self.assertEqual(recoveries, [True])
+
+    def test_successful_camera_attempt_does_not_restore_expander_i2c(self):
+        attempts = []
+        failures = []
+        recoveries = []
+        camera = object()
+
+        def init_camera():
+            attempts.append(True)
+            if len(attempts) < 3:
+                raise OSError("camera unavailable")
+            return camera
+
+        result = initialize_camera_with_recovery(
+            init_camera,
+            lambda attempt, error: failures.append(attempt),
+            lambda: recoveries.append(True),
+        )
+
+        self.assertTrue(result is camera)
+        self.assertEqual(len(attempts), 3)
+        self.assertEqual(failures, [0, 1])
+        self.assertEqual(recoveries, [])
 
 
 class TestK10ExpanderI2C(unittest.TestCase):

--- a/tests/test_unihiker_k10_input.py
+++ b/tests/test_unihiker_k10_input.py
@@ -1,6 +1,28 @@
 import unittest
 
-from mpos.board.unihiker_k10_input import K10ButtonInput
+from mpos.board.unihiker_k10_input import K10ButtonInput, create_expander_i2c
+
+
+class FakePin:
+    def __init__(self, number):
+        self.number = number
+
+
+class FakeI2C:
+    instances = []
+
+    def __init__(self, bus, sda, scl, freq):
+        self.args = (bus, sda.number, scl.number, freq)
+        self.registers = {0x06: 0xFF, 0x07: 0x00, 0x02: 0x00}
+        self.writes = []
+        self.instances.append(self)
+
+    def readfrom_mem(self, address, register, size):
+        return bytes([self.registers[register]])
+
+    def writeto_mem(self, address, register, value):
+        self.registers[register] = value[0]
+        self.writes.append((address, register, value[0]))
 
 
 class TestK10ButtonInput(unittest.TestCase):
@@ -30,6 +52,21 @@ class TestK10ButtonInput(unittest.TestCase):
         self.assertEqual(self.input.update(True, True, 120, False), ("next", False, False))
         self.assertEqual(self.input.update(False, False, 200, False), ("enter", True, False))
         self.assertEqual(self.input.update(False, False, 220, False), ("enter", False, False))
+
+
+class TestK10ExpanderI2C(unittest.TestCase):
+    def setUp(self):
+        FakeI2C.instances = []
+
+    def test_create_expander_i2c_recreates_and_configures_bus(self):
+        bus = create_expander_i2c(FakeI2C, FakePin, 47, 48)
+
+        self.assertTrue(bus is FakeI2C.instances[0])
+        self.assertEqual(bus.args, (0, 47, 48, 400000))
+        self.assertEqual(
+            bus.writes,
+            [(0x20, 0x06, 0xFC), (0x20, 0x07, 0x10), (0x20, 0x02, 0x03)],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_unihiker_k10_input.py
+++ b/tests/test_unihiker_k10_input.py
@@ -1,6 +1,10 @@
 import unittest
 
-from mpos.board.unihiker_k10_input import K10ButtonInput, create_expander_i2c
+from mpos.board.unihiker_k10_input import (
+    K10ButtonInput,
+    create_expander_i2c,
+    is_direct_navigation_target,
+)
 
 
 class FakePin:
@@ -39,13 +43,102 @@ class TestK10ButtonInput(unittest.TestCase):
         self.assertEqual(self.input.update(True, False, 800, False), (None, False, True))
         self.assertEqual(self.input.update(False, False, 820, False), (None, False, False))
 
+    def test_long_a_emits_escape_for_an_open_dropdown(self):
+        self.assertEqual(
+            self.input.update(True, False, 100, True, dropdown_open=True),
+            (None, False, False),
+        )
+        self.assertEqual(
+            self.input.update(True, False, 800, True, dropdown_open=True),
+            ("esc", True, False),
+        )
+        self.assertEqual(
+            self.input.update(True, False, 820, True, dropdown_open=True),
+            ("esc", False, False),
+        )
+        self.assertEqual(
+            self.input.update(False, False, 840, True, dropdown_open=True),
+            (None, False, False),
+        )
+
     def test_b_moves_to_next_widget(self):
         self.assertEqual(self.input.update(False, True, 100, False), ("next", True, False))
         self.assertEqual(self.input.update(False, False, 120, False), ("next", False, False))
 
+    def test_b_keeps_repeating_for_normal_navigation(self):
+        self.assertEqual(self.input.update(False, True, 100, False), ("next", True, False))
+        self.assertEqual(self.input.update(False, True, 800, False), ("next", True, False))
+        self.assertEqual(self.input.update(False, False, 820, False), ("next", False, False))
+
     def test_b_moves_to_next_keyboard_key(self):
         self.assertEqual(self.input.update(False, True, 100, True), ("right", True, False))
         self.assertEqual(self.input.update(False, False, 120, True), ("right", False, False))
+
+    def test_b_uses_next_for_a_closed_dropdown(self):
+        class Keyboard:
+            pass
+
+        class ButtonMatrix:
+            pass
+
+        class Dropdown:
+            def is_open(self):
+                return False
+
+        direct_navigation = is_direct_navigation_target(
+            Dropdown(), Keyboard, ButtonMatrix, Dropdown
+        )
+        self.assertFalse(direct_navigation)
+        self.assertEqual(
+            self.input.update(False, True, 100, direct_navigation),
+            ("next", True, False),
+        )
+
+    def test_short_b_moves_to_next_open_dropdown_option(self):
+        class Keyboard:
+            pass
+
+        class ButtonMatrix:
+            pass
+
+        class Dropdown:
+            def is_open(self):
+                return True
+
+        direct_navigation = is_direct_navigation_target(
+            Dropdown(), Keyboard, ButtonMatrix, Dropdown
+        )
+        self.assertTrue(direct_navigation)
+        self.assertEqual(
+            self.input.update(False, True, 100, direct_navigation, dropdown_open=True),
+            (None, False, False),
+        )
+        self.assertEqual(
+            self.input.update(False, False, 200, direct_navigation, dropdown_open=True),
+            ("right", True, False),
+        )
+        self.assertEqual(
+            self.input.update(False, False, 220, direct_navigation, dropdown_open=True),
+            ("right", False, False),
+        )
+
+    def test_long_b_moves_to_previous_open_dropdown_option(self):
+        self.assertEqual(
+            self.input.update(False, True, 100, True, dropdown_open=True),
+            (None, False, False),
+        )
+        self.assertEqual(
+            self.input.update(False, True, 800, True, dropdown_open=True),
+            ("left", True, False),
+        )
+        self.assertEqual(
+            self.input.update(False, True, 820, True, dropdown_open=True),
+            ("left", False, False),
+        )
+        self.assertEqual(
+            self.input.update(False, False, 840, True, dropdown_open=True),
+            (None, False, False),
+        )
 
     def test_a_takes_priority_when_b_is_also_pressed(self):
         self.assertEqual(self.input.update(False, True, 100, False), ("next", True, False))

--- a/tests/test_unihiker_k10_input.py
+++ b/tests/test_unihiker_k10_input.py
@@ -1,0 +1,36 @@
+import unittest
+
+from mpos.board.unihiker_k10_input import K10ButtonInput
+
+
+class TestK10ButtonInput(unittest.TestCase):
+    def setUp(self):
+        self.input = K10ButtonInput(long_press_ms=700)
+
+    def test_short_a_emits_enter_on_release(self):
+        self.assertEqual(self.input.update(True, False, 100, False), (None, False, False))
+        self.assertEqual(self.input.update(False, False, 200, False), ("enter", True, False))
+        self.assertEqual(self.input.update(False, False, 220, False), ("enter", False, False))
+
+    def test_long_a_emits_back_without_enter(self):
+        self.assertEqual(self.input.update(True, False, 100, False), (None, False, False))
+        self.assertEqual(self.input.update(True, False, 800, False), (None, False, True))
+        self.assertEqual(self.input.update(False, False, 820, False), (None, False, False))
+
+    def test_b_moves_to_next_widget(self):
+        self.assertEqual(self.input.update(False, True, 100, False), ("next", True, False))
+        self.assertEqual(self.input.update(False, False, 120, False), ("next", False, False))
+
+    def test_b_moves_to_next_keyboard_key(self):
+        self.assertEqual(self.input.update(False, True, 100, True), ("right", True, False))
+        self.assertEqual(self.input.update(False, False, 120, True), ("right", False, False))
+
+    def test_a_takes_priority_when_b_is_also_pressed(self):
+        self.assertEqual(self.input.update(False, True, 100, False), ("next", True, False))
+        self.assertEqual(self.input.update(True, True, 120, False), ("next", False, False))
+        self.assertEqual(self.input.update(False, False, 200, False), ("enter", True, False))
+        self.assertEqual(self.input.update(False, False, 220, False), ("enter", False, False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- add K10-specific short-press select and long-press back handling
- use B to move widget or keyboard focus with visible key highlighting
- keep Launcher and HowTo controls reachable on the two-button device
- cover the K10 button state machine with unit tests