### PR TITLE
FontManager: free an app's TTF and emoji fonts when the app quits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Future release (next version)
 =====
 
 Frameworks:
-- FontManager: delete an app's TTF and emoji fonts when the app closes, instead of leaking them, by @fdb
+- FontManager: stop leaking an app's TTF and emoji fonts after the app closes, by @fdb
 
 0.17.3
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Future release (next version)
 =====
 
+Frameworks:
+- FontManager: free TTF and emoji fonts once the last app activity closes, instead of leaking them per app, by @fdb
+
 0.17.3
 ======
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Future release (next version)
 =====
 
 Frameworks:
-- FontManager: free TTF and emoji fonts once the last app activity closes, instead of leaking them per app, by @fdb
+- FontManager: delete an app's TTF and emoji fonts when the app closes, instead of leaking them, by @fdb
 
 0.17.3
 ======

--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -102,15 +102,21 @@ lips,🫦
 
     @classmethod
     def getFont(cls, size=None, ttf=None, family=None, emoji=False):
-        """Return a font, loading and caching it on first use.
+        """Return a font for use in this app's widgets.
 
-        Lifetime: a font loaded with ttf= (and any emoji font composed on it)
-        is valid until the last activity of the running app closes. The OS
-        destroys it then, so the C heap it lives on is not leaked. Within an
-        app run you can keep and reuse the returned font freely, but do not
-        cache it in a service or thread that outlives your activities, and do
-        not apply it to OS-owned widgets such as lv.layer_top(). Builtin and
-        emoji-composed builtin fonts are never destroyed.
+        size picks the closest builtin size, family picks a builtin family
+        (e.g. "Montserrat"), ttf loads a custom font from a .ttf file, and
+        emoji=True adds emoji support on top of the chosen font.
+
+        Note: only use custom (ttf=) fonts in your activities. When your app
+        closes, the OS deletes its custom fonts, so the device does not
+        slowly run out of memory. Code that keeps running after your app
+        closes — a service, a thread, a timer, an LVGL callback — must not
+        hold on to a font: the font it remembers is gone, and drawing with
+        it crashes the device. For the same reason, do not put a custom font
+        on a system widget like lv.layer_top(), because it stays on screen
+        after your app closes. Fonts are cached, so calling getFont() again
+        is cheap. Builtin fonts are always safe.
         """
         target_size = cls._normalize_size(size)
 

--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -136,20 +136,21 @@ lips,🫦
 
     @classmethod
     def _clear_cache(cls):
-        """Destroy every cached TTF font and the emoji imgfonts composed on
-        them. Both come from lv_malloc(), which the MicroPython GC does not
-        manage, so dropping the Python reference alone leaks them and fragments
-        the C heap.
+        """Destroy all cached TTF fonts and the emoji fonts composed on them.
 
-        Destroying a font that something still uses is a use-after-free, and
-        apps may keep a font from getFont() in a variable and apply it later.
-        So only call this when no app code can run again with an old font: the
-        OS calls it once the last app activity is gone, because a relaunch
-        re-imports the app module with fresh globals. TTF fonts are for apps;
-        the launcher and system UI must use builtin fonts.
+        These fonts come from lv_malloc(). The MicroPython GC does not
+        manage that memory. If we only drop the Python reference, the
+        memory leaks and the C heap fragments.
 
-        Composed fonts over builtin fonts stay cached: the builtin font list
-        bounds how many can ever exist, so they are not a per-app leak.
+        Apps can keep a font from getFont() in a variable and apply it
+        later. If we destroy a font that an app still holds, the app
+        crashes on the next draw. So call this only when no app code can
+        run again. The OS calls it when the last app activity is gone.
+        A relaunch re-imports the app module, so old references cannot
+        come back. The launcher and system UI must use builtin fonts.
+
+        Emoji fonts composed on builtin fonts stay cached. The builtin
+        font list bounds their count, so they are not a per-app leak.
         """
         if not cls._ttf_font_cache:
             return
@@ -158,7 +159,7 @@ lips,🫦
         for font in cls._ttf_font_cache.values():
             ttf_ids.add(cls._font_identity(font))
 
-        # Destroy composed fonts before the TTFs they hold as fallback.
+        # Destroy composed fonts first. They hold a TTF as fallback.
         for cache_key in list(cls._composed_font_cache.keys()):
             if cache_key[0] not in ttf_ids:
                 continue

--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -108,15 +108,19 @@ lips,🫦
         (e.g. "Montserrat"), ttf loads a custom font from a .ttf file, and
         emoji=True adds emoji support on top of the chosen font.
 
-        Note: only use custom (ttf=) fonts in your activities. When your app
-        closes, the OS deletes its custom fonts, so the device does not
-        slowly run out of memory. Code that keeps running after your app
-        closes — a service, a thread, a timer, an LVGL callback — must not
-        hold on to a font: the font it remembers is gone, and drawing with
-        it crashes the device. For the same reason, do not put a custom font
-        on a system widget like lv.layer_top(), because it stays on screen
-        after your app closes. Fonts are cached, so calling getFont() again
-        is cheap. Builtin fonts are always safe.
+        When your app closes, the OS deletes custom (ttf=) fonts to keep
+        memory free.
+
+        - Use a custom font in your activities only.
+        - Do not keep a custom font in a service, a thread, a timer, or an
+          LVGL callback.
+        - Do not put a custom font on a system widget such as lv.layer_top().
+
+        This code can run after your app closes. A deleted font crashes the
+        device.
+
+        Fonts are cached, so it is cheap to call getFont() again. Builtin
+        fonts are always safe.
         """
         target_size = cls._normalize_size(size)
 

--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -102,6 +102,16 @@ lips,🫦
 
     @classmethod
     def getFont(cls, size=None, ttf=None, family=None, emoji=False):
+        """Return a font, loading and caching it on first use.
+
+        Lifetime: a font loaded with ttf= (and any emoji font composed on it)
+        is valid until the last activity of the running app closes. The OS
+        destroys it then, so the C heap it lives on is not leaked. Within an
+        app run you can keep and reuse the returned font freely, but do not
+        cache it in a service or thread that outlives your activities, and do
+        not apply it to OS-owned widgets such as lv.layer_top(). Builtin and
+        emoji-composed builtin fonts are never destroyed.
+        """
         target_size = cls._normalize_size(size)
 
         if ttf is None:
@@ -113,6 +123,47 @@ lips,🫦
             return base_font
 
         return cls._get_composed_font(base_font)
+
+    @classmethod
+    def _clear_cache(cls):
+        """Destroy every cached TTF font and the emoji imgfonts composed on
+        them. Both come from lv_malloc(), which the MicroPython GC does not
+        manage, so dropping the Python reference alone leaks them and fragments
+        the C heap.
+
+        Destroying a font that something still uses is a use-after-free, and
+        apps may keep a font from getFont() in a variable and apply it later.
+        So only call this when no app code can run again with an old font: the
+        OS calls it once the last app activity is gone, because a relaunch
+        re-imports the app module with fresh globals. TTF fonts are for apps;
+        the launcher and system UI must use builtin fonts.
+
+        Composed fonts over builtin fonts stay cached: the builtin font list
+        bounds how many can ever exist, so they are not a per-app leak.
+        """
+        if not cls._ttf_font_cache:
+            return
+
+        ttf_ids = set()
+        for font in cls._ttf_font_cache.values():
+            ttf_ids.add(cls._font_identity(font))
+
+        # Destroy composed fonts before the TTFs they hold as fallback.
+        for cache_key in list(cls._composed_font_cache.keys()):
+            if cache_key[0] not in ttf_ids:
+                continue
+            composed_font = cls._composed_font_cache.pop(cache_key)
+            try:
+                lv.imgfont_destroy(composed_font)
+            except Exception as err:
+                cls._debug("imgfont_destroy failed: " + repr(err))
+
+        for cache_key in list(cls._ttf_font_cache.keys()):
+            font = cls._ttf_font_cache.pop(cache_key)
+            try:
+                lv.tiny_ttf_destroy(font)
+            except Exception as err:
+                cls._debug("tiny_ttf_destroy failed: " + repr(err))
 
     @classmethod
     def normalizeEmojiText(cls, text):

--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -108,19 +108,10 @@ lips,🫦
         (e.g. "Montserrat"), ttf loads a custom font from a .ttf file, and
         emoji=True adds emoji support on top of the chosen font.
 
-        When your app closes, the OS deletes custom (ttf=) fonts to keep
-        memory free.
-
-        - Use a custom font in your activities only.
-        - Do not keep a custom font in a service, a thread, a timer, or an
-          LVGL callback.
-        - Do not put a custom font on a system widget such as lv.layer_top().
-
-        This code can run after your app closes. A deleted font crashes the
-        device.
-
-        Fonts are cached, so it is cheap to call getFont() again. Builtin
-        fonts are always safe.
+        Fonts are cached, so it is cheap to call getFont() again. When
+        your app closes, the OS drops custom (ttf=) fonts from the cache.
+        The garbage collector then reclaims each font once nothing uses
+        it. A font that you still hold stays valid.
         """
         target_size = cls._normalize_size(size)
 
@@ -136,18 +127,14 @@ lips,🫦
 
     @classmethod
     def _clear_cache(cls):
-        """Destroy all cached TTF fonts and the emoji fonts composed on them.
+        """Drop the cached TTF fonts and the emoji fonts composed on them.
 
-        These fonts come from lv_malloc(). The MicroPython GC does not
-        manage that memory. If we only drop the Python reference, the
-        memory leaks and the C heap fragments.
-
-        Apps can keep a font from getFont() in a variable and apply it
-        later. If we destroy a font that an app still holds, the app
-        crashes on the next draw. So call this only when no app code can
-        run again. The OS calls it when the last app activity is gone.
-        A relaunch re-imports the app module, so old references cannot
-        come back. The launcher and system UI must use builtin fonts.
+        LVGL allocates from the MicroPython GC heap in this build
+        (lv_conf.h sets LV_USE_STDLIB_MALLOC to LV_STDLIB_MPY). So it is
+        enough to drop the cache references: the GC reclaims a font once
+        nothing uses it, and keeps a font that an app, a widget, or a
+        style still holds. Never destroy fonts here: destroy frees memory
+        that an app can still draw with, and that crashes the device.
 
         Emoji fonts composed on builtin fonts stay cached. The builtin
         font list bounds their count, so they are not a per-app leak.
@@ -159,22 +146,10 @@ lips,🫦
         for font in cls._ttf_font_cache.values():
             ttf_ids.add(cls._font_identity(font))
 
-        # Destroy composed fonts first. They hold a TTF as fallback.
         for cache_key in list(cls._composed_font_cache.keys()):
-            if cache_key[0] not in ttf_ids:
-                continue
-            composed_font = cls._composed_font_cache.pop(cache_key)
-            try:
-                lv.imgfont_destroy(composed_font)
-            except Exception as err:
-                cls._debug("imgfont_destroy failed: " + repr(err))
-
-        for cache_key in list(cls._ttf_font_cache.keys()):
-            font = cls._ttf_font_cache.pop(cache_key)
-            try:
-                lv.tiny_ttf_destroy(font)
-            except Exception as err:
-                cls._debug("tiny_ttf_destroy failed: " + repr(err))
+            if cache_key[0] in ttf_ids:
+                del cls._composed_font_cache[cache_key]
+        cls._ttf_font_cache.clear()
 
     @classmethod
     def normalizeEmojiText(cls, text):
@@ -320,18 +295,22 @@ lips,🫦
         if key in cls._ttf_font_cache:
             return cls._ttf_font_cache[key]
 
-        cls._assert_ttf_exists(ttf_path)
-        font = lv.tiny_ttf_create_file(ttf_path, size)
+        # tiny_ttf_create_file keeps a file open that only a destroy call
+        # closes. We never destroy (the GC reclaims dropped fonts), so
+        # load the file into memory. The font keeps the data alive.
+        data = cls._read_ttf(ttf_path)
+        font = lv.tiny_ttf_create_data(data, len(data), size)
         cls._ttf_font_cache[key] = font
         return font
 
     @classmethod
-    def _assert_ttf_exists(cls, ttf_path):
+    def _read_ttf(cls, ttf_path):
         path = ttf_path
         if isinstance(path, str) and path.startswith("M:"):
             path = path[2:]
         try:
-            os.stat(path)
+            with open(path, "rb") as ttf_file:
+                return ttf_file.read()
         except OSError:
             raise OSError("TTF file not found: {}".format(ttf_path))
 

--- a/internal_filesystem/lib/mpos/ui/view.py
+++ b/internal_filesystem/lib/mpos/ui/view.py
@@ -77,7 +77,7 @@ def remove_and_stop_all_activities():
     global screen_stack
     while len(screen_stack):
         remove_and_stop_current_activity()
-    # Every app is gone. Destroy the TTF fonts that apps loaded.
+    # Every app is gone. Drop the cached TTF fonts.
     FontManager._clear_cache()
 
 def remove_and_stop_current_activity():
@@ -159,10 +159,9 @@ def finish_current_activity():
 
     if len(screen_stack) == 1:
         open_bar()
-        # Only the launcher is left. No app code can use an old font now:
-        # a relaunch re-imports the app module with fresh globals.
-        # Do not destroy fonts sooner. An app can keep a font in a variable
-        # and apply it again in its next activity.
+        # Only the launcher is left. Drop the app fonts from the cache, so
+        # the GC can reclaim them. A font that app code still holds stays
+        # alive until that code is gone too.
         FontManager._clear_cache()
 
     return True

--- a/internal_filesystem/lib/mpos/ui/view.py
+++ b/internal_filesystem/lib/mpos/ui/view.py
@@ -2,6 +2,7 @@ import logging
 import lvgl as lv
 import sys
 
+from .font_manager import FontManager
 from .input_manager import InputManager
 from .topmenu import open_bar, close_drawer
 
@@ -76,6 +77,8 @@ def remove_and_stop_all_activities():
     global screen_stack
     while len(screen_stack):
         remove_and_stop_current_activity()
+    # Every app is gone, so release the TTF fonts they loaded.
+    FontManager._clear_cache()
 
 def remove_and_stop_current_activity():
     global _orphan_screen
@@ -156,6 +159,11 @@ def finish_current_activity():
 
     if len(screen_stack) == 1:
         open_bar()
+        # Only the launcher is left, so no app code can reuse a font it cached
+        # earlier: a relaunch re-imports the app module with fresh globals.
+        # Freeing any sooner is unsafe — an app that keeps a font in a Python
+        # variable across its own sub-activities would get a dangling font.
+        FontManager._clear_cache()
 
     return True
 

--- a/internal_filesystem/lib/mpos/ui/view.py
+++ b/internal_filesystem/lib/mpos/ui/view.py
@@ -77,7 +77,7 @@ def remove_and_stop_all_activities():
     global screen_stack
     while len(screen_stack):
         remove_and_stop_current_activity()
-    # Every app is gone, so release the TTF fonts they loaded.
+    # Every app is gone. Destroy the TTF fonts that apps loaded.
     FontManager._clear_cache()
 
 def remove_and_stop_current_activity():
@@ -159,10 +159,10 @@ def finish_current_activity():
 
     if len(screen_stack) == 1:
         open_bar()
-        # Only the launcher is left, so no app code can reuse a font it cached
-        # earlier: a relaunch re-imports the app module with fresh globals.
-        # Freeing any sooner is unsafe — an app that keeps a font in a Python
-        # variable across its own sub-activities would get a dangling font.
+        # Only the launcher is left. No app code can use an old font now:
+        # a relaunch re-imports the app module with fresh globals.
+        # Do not destroy fonts sooner. An app can keep a font in a variable
+        # and apply it again in its next activity.
         FontManager._clear_cache()
 
     return True

--- a/tests/manual_test_meshcore_font_reentry.py
+++ b/tests/manual_test_meshcore_font_reentry.py
@@ -1,0 +1,62 @@
+"""Reproduce the MeshCore font crash on the emulator (manual test).
+
+Needs the real MeshCore app installed in apps/org.fri3d.meshcore
+(download from BadgeHub). Launches the app, opens the Public channel,
+goes back, and opens it again — the exact flow that crashed on the
+badge with #248. With the #248 behavior the second open draws with a
+destroyed font: the process crashes, or the final cache assert fails.
+With the fix the flow completes.
+
+Usage:
+    uv run scripts/test_runner.py tests/manual_test_meshcore_font_reentry.py
+"""
+
+import unittest
+
+import mpos.ui
+from mpos import AppManager, FontManager, wait_for_render
+
+
+class TestMeshCoreChannelReentry(unittest.TestCase):
+
+    def tearDown(self):
+        for _ in range(10):
+            if len(mpos.ui.screen_stack) <= 1:
+                break
+            mpos.ui.back_screen()
+            wait_for_render(5)
+
+    def test_channel_reenter_does_not_crash(self):
+        self.assertTrue(AppManager.start_app("org.fri3d.meshcore"),
+                        "MeshCore failed to launch — is it installed in apps/?")
+        wait_for_render(10)
+        home = mpos.ui.screen_stack[-1][0]
+        self.assertEqual(type(home).__name__, "MeshCoreHome")
+
+        # Open the Public channel, like a tap on its row.
+        home._open_channel("Public")
+        wait_for_render(10)
+        self.assertEqual(
+            type(mpos.ui.screen_stack[-1][0]).__name__, "ChannelChatActivity")
+        # The chat screen must use the real TTF, not the Montserrat fallback.
+        self.assertEqual(len(FontManager._ttf_font_cache), 1,
+                         "Archivo Narrow did not load; test proves nothing")
+
+        # Back to the home screen. MeshCore still runs.
+        mpos.ui.back_screen()
+        wait_for_render(10)
+
+        # Open the channel again. MeshCore applies the font it kept in its
+        # module global. With #248 that font was destroyed on the back
+        # navigation, and this render reads freed memory.
+        home._open_channel("Public")
+        wait_for_render(30)
+        self.assertEqual(
+            type(mpos.ui.screen_stack[-1][0]).__name__, "ChannelChatActivity")
+
+        # The held font must stay cached while the app runs.
+        self.assertEqual(len(FontManager._ttf_font_cache), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graphical_font_manager.py
+++ b/tests/test_graphical_font_manager.py
@@ -167,7 +167,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         _reset_font_manager()
 
     def test_clear_cache_empties_ttf_cache(self):
-        """_clear_cache() releases every cached TTF font."""
+        """_clear_cache() destroys every cached TTF font."""
         FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
         self.assertTrue(len(FontManager._ttf_font_cache) > 0)
 
@@ -176,7 +176,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         self.assertEqual(len(FontManager._ttf_font_cache), 0)
 
     def test_clear_cache_drops_composed_ttf_fonts(self):
-        """Composed fonts wrapping a TTF are released along with the TTF."""
+        """_clear_cache() destroys composed fonts together with their TTF."""
         base = FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
         FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=True)
         base_id = FontManager._font_identity(base)
@@ -189,7 +189,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         self.assertEqual(len(remaining), 0)
 
     def test_clear_cache_keeps_builtin_composed_fonts(self):
-        """Composed fonts over builtin fonts survive: system UI holds live references."""
+        """Composed fonts over builtin fonts stay cached."""
         composed = FontManager.getFont(size=16, family="Montserrat", emoji=True)
 
         FontManager._clear_cache()
@@ -199,7 +199,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         )
 
     def test_clear_cache_allows_reload(self):
-        """A TTF font requested after _clear_cache() is usable again."""
+        """getFont() loads a TTF again after _clear_cache()."""
         FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
         FontManager._clear_cache()
 
@@ -208,7 +208,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         self.assertTrue(font.get_line_height() > 0)
 
     def test_clear_cache_on_empty_caches(self):
-        """_clear_cache() is safe when nothing was ever cached."""
+        """_clear_cache() is safe when the cache is empty."""
         FontManager._clear_cache()
         self.assertEqual(len(FontManager._ttf_font_cache), 0)
 
@@ -216,11 +216,11 @@ class TestFontManagerClearCache(GraphicalTestCase):
 class TestFontManagerAppHeldFont(GraphicalTestCase):
     """Regression test for the MeshCore crash.
 
-    MeshCore keeps its TTF font in a module global and applies it each time a
-    chat channel screen is built. Freeing the font when the channel activity
-    finishes leaves that global dangling, so re-entering the channel renders
-    with freed memory and crashes. The OS must keep app fonts alive for as
-    long as any activity of the app is on the stack.
+    MeshCore keeps its TTF font in a module global. It applies the font
+    each time it builds a chat channel screen. If the OS destroys the font
+    when the channel activity finishes, the global points to freed memory.
+    The next channel screen then crashes the device. So the OS must keep
+    app fonts until the last activity of the app is gone.
     """
 
     def setUp(self):
@@ -232,9 +232,9 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
                 break
             mpos.ui.back_screen()
             self.wait_for_render()
-        # Fonts are freed when only the launcher remains (stack length 1). If
-        # this test environment has no launcher, push a stand-in so the stack
-        # floor is 1, like on a running system.
+        # The OS destroys fonts when only the launcher remains (stack
+        # length 1). If this test environment has no launcher, push a
+        # stand-in, so the stack floor is 1, like on a running system.
         self._pushed_launcher_standin = False
         if not mpos.ui.screen_stack:
             self._push_activity()
@@ -265,16 +265,16 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
         return activity
 
     def test_held_font_survives_sub_activity_finish(self):
-        """A font the app holds in a variable stays valid across a sub-activity
-        finish, and is freed once the app's last activity is gone."""
+        """A font held in a variable stays valid across a sub-activity
+        finish. The OS destroys it once the app's last activity is gone."""
         import mpos.ui
         from mpos.ui.view import finish_current_activity
 
         # App home activity (like the MeshCore home tabs).
         self._push_activity()
 
-        # The app loads the TTF once and keeps the reference, then applies it
-        # inside a sub-activity (like a chat channel screen).
+        # The app loads the TTF once and keeps the reference. It applies
+        # the font inside a sub-activity (like a chat channel screen).
         held_font = FontManager.getFont(size=14, ttf=_TEST_TTF_PATH)
 
         def build_channel(screen):
@@ -284,18 +284,18 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
 
         self._push_activity(build_channel)
 
-        # Back out of the sub-activity. The app still runs, so the held font
-        # must survive even though no widget draws with it right now.
+        # Back out of the sub-activity. The app still runs, so the held
+        # font must stay valid, although no widget draws with it now.
         finish_current_activity()
         self.wait_for_render()
         self.assertEqual(len(FontManager._ttf_font_cache), 1)
 
-        # Re-enter the sub-activity and apply the held font again. With the
-        # font freed this render dereferences freed memory (the crash).
+        # Re-enter the sub-activity and apply the held font again. If the
+        # font was destroyed, this render reads freed memory and crashes.
         self._push_activity(build_channel)
         self.wait_for_render(10)
 
-        # Quit the app: with only the launcher left, the font is released.
+        # Quit the app. Only the launcher is left, so the OS destroys the font.
         finish_current_activity()
         self.wait_for_render()
         finish_current_activity()

--- a/tests/test_graphical_font_manager.py
+++ b/tests/test_graphical_font_manager.py
@@ -167,7 +167,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         _reset_font_manager()
 
     def test_clear_cache_empties_ttf_cache(self):
-        """_clear_cache() destroys every cached TTF font."""
+        """_clear_cache() drops every cached TTF font."""
         FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
         self.assertTrue(len(FontManager._ttf_font_cache) > 0)
 
@@ -176,7 +176,7 @@ class TestFontManagerClearCache(GraphicalTestCase):
         self.assertEqual(len(FontManager._ttf_font_cache), 0)
 
     def test_clear_cache_drops_composed_ttf_fonts(self):
-        """_clear_cache() destroys composed fonts together with their TTF."""
+        """_clear_cache() drops composed fonts together with their TTF."""
         base = FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
         FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=True)
         base_id = FontManager._font_identity(base)
@@ -217,10 +217,10 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
     """Regression test for the MeshCore crash.
 
     MeshCore keeps its TTF font in a module global. It applies the font
-    each time it builds a chat channel screen. If the OS destroys the font
-    when the channel activity finishes, the global points to freed memory.
-    The next channel screen then crashes the device. So the OS must keep
-    app fonts until the last activity of the app is gone.
+    each time it builds a chat channel screen. When #248 destroyed the
+    font on the back navigation, the global pointed to freed memory, and
+    the next channel screen crashed the device. A held font must stay
+    valid for as long as the app can apply it.
     """
 
     def setUp(self):
@@ -232,7 +232,7 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
                 break
             mpos.ui.back_screen()
             self.wait_for_render()
-        # The OS destroys fonts when only the launcher remains (stack
+        # The OS drops cached fonts when only the launcher remains (stack
         # length 1). If this test environment has no launcher, push a
         # stand-in, so the stack floor is 1, like on a running system.
         self._pushed_launcher_standin = False
@@ -266,7 +266,7 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
 
     def test_held_font_survives_sub_activity_finish(self):
         """A font held in a variable stays valid across a sub-activity
-        finish. The OS destroys it once the app's last activity is gone."""
+        finish. The OS drops it from the cache once the app is gone."""
         import mpos.ui
         from mpos.ui.view import finish_current_activity
 
@@ -290,12 +290,12 @@ class TestFontManagerAppHeldFont(GraphicalTestCase):
         self.wait_for_render()
         self.assertEqual(len(FontManager._ttf_font_cache), 1)
 
-        # Re-enter the sub-activity and apply the held font again. If the
-        # font was destroyed, this render reads freed memory and crashes.
+        # Re-enter the sub-activity and apply the held font again. With
+        # #248 the font was destroyed here, and this render crashed.
         self._push_activity(build_channel)
         self.wait_for_render(10)
 
-        # Quit the app. Only the launcher is left, so the OS destroys the font.
+        # Quit the app. Only the launcher is left, so the cache is dropped.
         finish_current_activity()
         self.wait_for_render()
         finish_current_activity()

--- a/tests/test_graphical_font_manager.py
+++ b/tests/test_graphical_font_manager.py
@@ -159,6 +159,150 @@ class TestFontManagerGetFont(GraphicalTestCase):
         self.assertEqual(ptr.value, -int(base.base_line))
 
 
+class TestFontManagerClearCache(GraphicalTestCase):
+    """Tests for FontManager._clear_cache()."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_font_manager()
+
+    def test_clear_cache_empties_ttf_cache(self):
+        """_clear_cache() releases every cached TTF font."""
+        FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
+        self.assertTrue(len(FontManager._ttf_font_cache) > 0)
+
+        FontManager._clear_cache()
+
+        self.assertEqual(len(FontManager._ttf_font_cache), 0)
+
+    def test_clear_cache_drops_composed_ttf_fonts(self):
+        """Composed fonts wrapping a TTF are released along with the TTF."""
+        base = FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
+        FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=True)
+        base_id = FontManager._font_identity(base)
+        composed_keys = [k for k in FontManager._composed_font_cache if k[0] == base_id]
+        self.assertTrue(len(composed_keys) > 0)
+
+        FontManager._clear_cache()
+
+        remaining = [k for k in FontManager._composed_font_cache if k[0] == base_id]
+        self.assertEqual(len(remaining), 0)
+
+    def test_clear_cache_keeps_builtin_composed_fonts(self):
+        """Composed fonts over builtin fonts survive: system UI holds live references."""
+        composed = FontManager.getFont(size=16, family="Montserrat", emoji=True)
+
+        FontManager._clear_cache()
+
+        self.assertIs(
+            FontManager.getFont(size=16, family="Montserrat", emoji=True), composed
+        )
+
+    def test_clear_cache_allows_reload(self):
+        """A TTF font requested after _clear_cache() is usable again."""
+        FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
+        FontManager._clear_cache()
+
+        font = FontManager.getFont(size=24, ttf=_TEST_TTF_PATH, emoji=False)
+        self.assertIsNotNone(font)
+        self.assertTrue(font.get_line_height() > 0)
+
+    def test_clear_cache_on_empty_caches(self):
+        """_clear_cache() is safe when nothing was ever cached."""
+        FontManager._clear_cache()
+        self.assertEqual(len(FontManager._ttf_font_cache), 0)
+
+
+class TestFontManagerAppHeldFont(GraphicalTestCase):
+    """Regression test for the MeshCore crash.
+
+    MeshCore keeps its TTF font in a module global and applies it each time a
+    chat channel screen is built. Freeing the font when the channel activity
+    finishes leaves that global dangling, so re-entering the channel renders
+    with freed memory and crashes. The OS must keep app fonts alive for as
+    long as any activity of the app is on the stack.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _reset_font_manager()
+        import mpos.ui
+        for _ in range(10):
+            if len(mpos.ui.screen_stack) <= 1:
+                break
+            mpos.ui.back_screen()
+            self.wait_for_render()
+        # Fonts are freed when only the launcher remains (stack length 1). If
+        # this test environment has no launcher, push a stand-in so the stack
+        # floor is 1, like on a running system.
+        self._pushed_launcher_standin = False
+        if not mpos.ui.screen_stack:
+            self._push_activity()
+            self._pushed_launcher_standin = True
+
+    def tearDown(self):
+        import mpos.ui
+        from mpos.ui.view import finish_current_activity
+        for _ in range(10):
+            if len(mpos.ui.screen_stack) <= 1:
+                break
+            finish_current_activity()
+            self.wait_for_render()
+        if self._pushed_launcher_standin and mpos.ui.screen_stack:
+            mpos.ui.remove_and_stop_current_activity()
+            self.wait_for_render()
+        super().tearDown()
+
+    def _push_activity(self, build_screen=None):
+        from mpos import Activity
+        import mpos.ui
+        activity = Activity()
+        screen = lv.obj(None)
+        if build_screen:
+            build_screen(screen)
+        mpos.ui.setContentView(activity, screen)
+        self.wait_for_render()
+        return activity
+
+    def test_held_font_survives_sub_activity_finish(self):
+        """A font the app holds in a variable stays valid across a sub-activity
+        finish, and is freed once the app's last activity is gone."""
+        import mpos.ui
+        from mpos.ui.view import finish_current_activity
+
+        # App home activity (like the MeshCore home tabs).
+        self._push_activity()
+
+        # The app loads the TTF once and keeps the reference, then applies it
+        # inside a sub-activity (like a chat channel screen).
+        held_font = FontManager.getFont(size=14, ttf=_TEST_TTF_PATH)
+
+        def build_channel(screen):
+            label = lv.label(screen)
+            label.set_style_text_font(held_font, lv.PART.MAIN)
+            label.set_text("chat channel")
+
+        self._push_activity(build_channel)
+
+        # Back out of the sub-activity. The app still runs, so the held font
+        # must survive even though no widget draws with it right now.
+        finish_current_activity()
+        self.wait_for_render()
+        self.assertEqual(len(FontManager._ttf_font_cache), 1)
+
+        # Re-enter the sub-activity and apply the held font again. With the
+        # font freed this render dereferences freed memory (the crash).
+        self._push_activity(build_channel)
+        self.wait_for_render(10)
+
+        # Quit the app: with only the launcher left, the font is released.
+        finish_current_activity()
+        self.wait_for_render()
+        finish_current_activity()
+        self.wait_for_render()
+        self.assertEqual(len(FontManager._ttf_font_cache), 0)
+
+
 class TestFontManagerListFonts(GraphicalTestCase):
     """Tests for FontManager.listFonts()."""
 


### PR DESCRIPTION
Second attempt at #248, which was reverted in #254 because the MeshCore app crashed when re-entering a chat channel.

## The bug in #248

I looked at the #248 implementation and at how MeshCore uses fonts, and found the issue: MeshCore caches the font handle in a module global and applies it each time a chat channel screen is built. #248's `clear_cache()` freed fonts whenever an activity finished, scanning the widget tree to decide what was still in use. But a widget scan only sees fonts currently applied to a widget — it cannot see a handle an app keeps in a Python variable for later. So:
enter channel → back (font freed) → enter channel again (freed font applied to a new label) → use-after-free.

## The root cause

MeshCore's caching the font in a global is normal app code, not some weird edge case, so we absolutely need to support this. The real problem is that `getFont()` returns an object with no explicit lifetime contract, held forever by FontManager's own cache: `_ttf_font_cache` is a class attribute on an OS-lifetime singleton, so every font any app ever loaded stays reachable for the rest of the session. The app's own references die with the app — the OS's cache reference is what pins the memory.

A deep dive into lvgl_micropython showed that the fonts themselves are already managed: LVGL allocates from the MicroPython GC heap (`lv_conf.h` sets `LV_USE_STDLIB_MALLOC = LV_STDLIB_MPY`), and the conservative GC follows C-side references too — a style or widget that holds an `lv_font_t*` keeps that font alive. We verified this empirically: a font referenced only by a C-side style survives `gc.collect()`, and is reclaimed after `style.reset()`, with no destroy call.

## The fix

Since the GC already tracks who still holds a font, we only drop the cache references when the app quits. That happens in two places — `finish_current_activity()` when the stack drops to launcher-only, and `remove_and_stop_all_activities()`. The GC then reclaims each font once nothing uses it, and keeps every font that an app, a widget, or a thread still holds. Use-after-free is impossible by construction: we never free memory; the GC frees only what is unreachable. Fonts shared by stacked apps (same TTF path and size) are dropped only once all of them are gone.

This also made the code simpler:

- No destroy calls. `_clear_cache()` removes dictionary entries; `tiny_ttf_destroy()` / `imgfont_destroy()` are never called.
- The widget-tree walk is gone. It existed to decide when freeing was safe. Nothing is freed anymore, so there is nothing to decide.
- `_get_ttf_font()` reads the .ttf into memory and calls `tiny_ttf_create_data()` instead of `tiny_ttf_create_file()`. This is load-bearing: a file-based font keeps an `lv_fs` file open that only a destroy call closes — the one resource the GC cannot see. A data-based font keeps its buffer alive through the GC, so both are reclaimed together.
- The method is private (`_clear_cache()`): it has one caller, the OS teardown path in `view.py`.
- The `getFont()` docstring documents the contract: fonts are cached; the OS drops an app's custom fonts from the cache when the app quits; a font you still hold stays valid — from anywhere: activities, services, threads, LVGL callbacks, "Open With" handlers.

Again the goal of #248 still holds: avoid font leaks and heap fragmentation for apps that use custom fonts — by dropping the cache references so the GC reclaims the fonts once they're no longer in use.

## Tests

New regression test `TestFontManagerAppHeldFont` replays the MeshCore sequence: font held in a variable, sub-activity finished, font re-applied and rendered, then dropped from the cache once the app's last activity is gone. It fails against the #248 behavior (3/3 runs) and passes with this change. All 64 font manager tests and the activity-stack navigation tests pass.

On the desktop emulator with the real MeshCore app from BadgeHub, channel → back → channel survives (the flow that crashed #248 with SIGBUS), and quitting to the launcher lets the GC reclaim ~110 KB. `tests/manual_test_meshcore_font_reentry.py` replays this flow.
