### PR TITLE
Add CTRL-SHIFT-S screenshot hotkey to the desktop emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ conf.json*
 # auto created when running on desktop:
 internal_filesystem/SDLPointer_2
 internal_filesystem/SDLPointer_3
+internal_filesystem/screenshot-*.bmp
 
 internal_filesystem.mpy/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Frameworks:
 - Camera: after decoding a QR code in free-scan mode, show an "Open in App Store" / "Open link" chip when the code is an app link the OS can open
 - DeepLink: new mpos.content.deeplink module with strict app-link parsing (exact host allowlist, identity-only links) and URL dispatch
 - FontManager: stop leaking an app's TTF and emoji fonts after the app closes, by @fdb
+- Screenshot: move the BMP encoder out of the web server into mpos.ui.testing.encode_bmp(), which both now share, and add save_screenshot_bmp() to capture the screen straight into a file
 - TaskManager: add create_supervised_task(restart_on_return=True) and use it for the aiorepl console, so it is restarted when it exits
 
 OS:
@@ -24,6 +25,7 @@ OS:
 - lvgl_micropython: compress Montserrat 10-18 fonts to save ~19 KB of flash space
 - lvgl_micropython: add native-decorator bytecode fallback for builds without a native emitter like the unix port on aarch64 (Apple Silicon macOS) and the wasm/web port
 - main.py: skip the lib/ override when lib/mpos is from a different release than the frozen firmware, instead of letting a stale lib/ (as flashed by the web installer) shadow the new frozen modules after an OTA update and crash the launcher at boot (#239)
+- sdl_keyboard: CTRL-SHIFT-S (CMD-SHIFT-S on macOS) saves a timestamped BMP screenshot in the current directory, at the screen's own pixel size instead of the scaled SDL window
 
 Testing:
 - test_runner: monkeypatch asyncio.run / new_event_loop / Loop.run_until_complete with wrappers that save and restore the outer asyncio.core globals (cur_task, _task_queue, _io_queue) so tests running inside the TaskManager's event loop via paste mode no longer segfault on nested asyncio operations

--- a/internal_filesystem/lib/drivers/indev/sdl_keyboard.py
+++ b/internal_filesystem/lib/drivers/indev/sdl_keyboard.py
@@ -1,8 +1,11 @@
+import logging
 import lvgl as lv
 from micropython import const  # NOQA
 import micropython  # NOQA  # NOQA
 import keypad_framework
 import mpos.clipboard
+
+logger = logging.getLogger(__name__)
 
 KEY_UNKNOWN = 0
 KEY_BACKSPACE = 8  # LV_KEY_BACKSPACE
@@ -52,6 +55,7 @@ KEY_CARET = 94  # ^
 KEY_UNDERSCORE = 95  # _
 KEY_BACKQUOTE = 96  # `
 KEY_a = 97  # a
+KEY_s = 115  # s
 KEY_z = 122  # z
 KEY_DELETE = 127  # LV_KEY_DEL
 
@@ -239,6 +243,16 @@ class MposSDLKeyboard(keypad_framework.KeypadDriver):
                 if clipboard_text:
                     self.paste_text_callback(clipboard_text)
                 return
+
+        # CTRL-SHIFT-S (CMD-SHIFT-S on macOS) saves a screenshot in the current directory
+        if (state == 1 and key == KEY_s and mod & MOD_KEY_SHIFT
+                and mod & (MOD_KEY_CTRL | MOD_KEY_META)):
+            from mpos.ui.testing import save_screenshot_bmp
+            try:
+                print(f"Saved screenshot to {save_screenshot_bmp()}")
+            except Exception as e:
+                logger.warning("Could not save screenshot: %s", e)
+            return
 
         # Skip modifier keys and SDL-specific large keycodes (>= 2^30), except keypad, nav, and func keys
         if (key in {KEY_LSHIFT, KEY_RSHIFT, KEY_LCTRL, KEY_RCTRL, KEY_LALT, KEY_RALT,

--- a/internal_filesystem/lib/mpos/__init__.py
+++ b/internal_filesystem/lib/mpos/__init__.py
@@ -42,7 +42,8 @@ from .ui.camera_activity import CameraActivity
 from .ui.file_explorer_activity import FileExplorerActivity
 from .ui.keyboard import MposKeyboard
 from .ui.testing import (
-    wait_for_render, capture_screenshot, simulate_click, simulate_drag, get_widget_coords,
+    wait_for_render, capture_screenshot, save_screenshot_bmp, simulate_click, simulate_drag,
+    get_widget_coords,
     find_label_with_text, verify_text_present, print_screen_labels, find_text_on_screen,
     click_button, click_label, click_keyboard_button, find_button_with_text,
     get_all_widgets_with_text, find_setting_value_label, get_setting_value_text,
@@ -117,7 +118,8 @@ __all__ = (
     "focus_direction",
     "NumberFormat",
     # Testing utilities
-    "wait_for_render", "capture_screenshot", "simulate_click", "simulate_drag", "get_widget_coords",
+    "wait_for_render", "capture_screenshot", "save_screenshot_bmp", "simulate_click", "simulate_drag",
+    "get_widget_coords",
     "find_label_with_text", "verify_text_present", "print_screen_labels", "find_text_on_screen",
     "click_button", "click_label", "click_keyboard_button", "find_button_with_text",
     "get_all_widgets_with_text", "find_setting_value_label", "get_setting_value_text",

--- a/internal_filesystem/lib/mpos/ui/testing.py
+++ b/internal_filesystem/lib/mpos/ui/testing.py
@@ -41,8 +41,11 @@ Usage in apps:
         simulate_click(area.x1 + 10, area.y1 + 10)
 """
 
+import gc
 import logging
 import lvgl as lv
+import os
+import struct
 import sys
 import time
 
@@ -466,6 +469,91 @@ def _blend_child(dst, src_argb, ox, oy, cw, ch, w, h, bpp, fmt):
                         dst[di + 1] = (src_argb[si + 1] * a + gd * ad * ai // 255) // oa
                         dst[di + 2] = (src_argb[si + 2] * a + rd * ad * ai // 255) // oa
                     dst[di + 3] = oa
+
+
+_BMP_HEADER_SIZE = 54
+
+
+def encode_bmp(pixels, width, height):
+    """
+    Encode an LVGL RGB888 buffer as a 24-bit BMP image.
+
+    Both formats hold three bytes per pixel, blue first, so the scanlines
+    are copied rather than converted.
+
+    Args:
+        pixels: Buffer holding width * height pixels of 3 bytes, blue first
+        width: Image width in pixels
+        height: Image height in pixels
+
+    Returns:
+        bytearray: The complete BMP file
+    """
+    rgb_size = width * height * 3
+    row_stride = ((width * 3 + 3) // 4) * 4
+    pixel_data_size = row_stride * height
+    bmp = bytearray(_BMP_HEADER_SIZE + pixel_data_size)
+
+    header = memoryview(bmp)[:_BMP_HEADER_SIZE]
+    header[0:2] = b"BM"
+    header[2:6] = struct.pack("<I", _BMP_HEADER_SIZE + pixel_data_size)
+    header[10:14] = struct.pack("<I", _BMP_HEADER_SIZE)
+    header[14:18] = struct.pack("<I", 40)
+    header[18:22] = struct.pack("<I", width)
+    header[22:26] = struct.pack("<i", -height)  # negative: rows run top to bottom
+    header[26:28] = struct.pack("<H", 1)
+    header[28:30] = struct.pack("<H", 24)
+    header[30:34] = struct.pack("<I", 0)
+    header[34:38] = struct.pack("<I", pixel_data_size)
+
+    view = memoryview(bmp)[_BMP_HEADER_SIZE:]
+    if row_stride == width * 3:
+        view[:rgb_size] = pixels
+    else:
+        for y in range(height):
+            src_start = y * width * 3
+            view[y * row_stride:y * row_stride + width * 3] = pixels[src_start:src_start + width * 3]
+    return bmp
+
+
+def screenshot_filename(now=None):
+    """Return a timestamped screenshot name, e.g. screenshot-20260818-221624.bmp."""
+    if now is None:
+        now = time.localtime()
+    return "screenshot-{:04d}{:02d}{:02d}-{:02d}{:02d}{:02d}.bmp".format(*now[:6])
+
+
+def save_screenshot_bmp(filepath=None, width=None, height=None, all_layers=True):
+    """
+    Capture the current screen and write it as a BMP file.
+
+    Args:
+        filepath: Where to write. Defaults to a timestamped name in the
+                  working directory, as an absolute path: the caller cannot
+                  see which directory that is, and on desktop it is the
+                  internal_filesystem the emulator was started in.
+        width: Screen width in pixels (default: the display width)
+        height: Screen height in pixels (default: the display height)
+        all_layers: Include lv.layer_top() overlays such as the status bar
+                    (default: True)
+
+    Returns:
+        str: The path that was written
+    """
+    from mpos.ui.display_metrics import DisplayMetrics
+    if width is None:
+        width = DisplayMetrics.width()
+    if height is None:
+        height = DisplayMetrics.height()
+    if filepath is None:
+        cwd = os.getcwd()
+        filepath = (cwd if cwd.endswith("/") else cwd + "/") + screenshot_filename()
+    gc.collect()  # the capture needs one contiguous frame buffer, plus one per overlay
+    pixels = capture_screenshot(width=width, height=height, color_format=lv.COLOR_FORMAT.RGB888,
+                                all_layers=all_layers)
+    with open(filepath, "wb") as f:
+        f.write(encode_bmp(pixels, width, height))
+    return filepath
 
 
 def get_all_widgets_with_text(obj, widgets=None):

--- a/internal_filesystem/lib/mpos/webserver/webrepl_http.py
+++ b/internal_filesystem/lib/mpos/webserver/webrepl_http.py
@@ -1,7 +1,6 @@
 import os
 import socket
 import uio
-import struct
 
 import _webrepl
 from . import webrepl
@@ -12,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from mpos.ui.display_metrics import DisplayMetrics
-from mpos.ui.testing import capture_screenshot
+from mpos.ui.testing import capture_screenshot, encode_bmp
 
 WEBREPL_HTML_PATH = "builtin/html/webrepl_inlined_minified.html.gz" # built by MicroPythonOS/webrepl/inline_minify_webrepl.py
 
@@ -79,46 +78,11 @@ def _send_response(cl, status, content_type, body, extra_headers=None):
     cl.close()
 
 
-def _build_bmp_header(width, height, pixel_data_size):
-    bmp_header_size = 54
-    file_size = bmp_header_size + pixel_data_size
-    header = bytearray(bmp_header_size)
-    header[0:2] = b"BM"
-    header[2:6] = struct.pack("<I", file_size)
-    header[10:14] = struct.pack("<I", bmp_header_size)
-    header[14:18] = struct.pack("<I", 40)
-    header[18:22] = struct.pack("<I", width)
-    header[22:26] = struct.pack("<i", -height)
-    header[26:28] = struct.pack("<H", 1)
-    header[28:30] = struct.pack("<H", 24)
-    header[30:34] = struct.pack("<I", 0)
-    header[34:38] = struct.pack("<I", pixel_data_size)
-    return header
-
-
 def _snapshot_to_bmp(all_layers=False):
     width = DisplayMetrics.width()
     height = DisplayMetrics.height()
-    rgb_size = width * height * 3
-    row_stride = ((width * 3 + 3) // 4) * 4
-    pixel_data_size = row_stride * height
-
     rgb_buffer = capture_screenshot(width=width, height=height, color_format=lv.COLOR_FORMAT.RGB888, all_layers=all_layers)
-
-    bmp = bytearray(54 + pixel_data_size)
-    bmp[0:54] = _build_bmp_header(width, height, pixel_data_size)
-
-    view = memoryview(bmp)[54:]
-    if row_stride == width * 3:
-        view[:rgb_size] = rgb_buffer
-    else:
-        for y in range(height):
-            src_start = y * width * 3
-            src_end = src_start + width * 3
-            dest_start = y * row_stride
-            view[dest_start : dest_start + width * 3] = rgb_buffer[src_start:src_end]
-
-    return bmp
+    return encode_bmp(rgb_buffer, width, height)
 
 
 def _send_file_response(cl, path, content_type, extra_headers=None):

--- a/tests/test_screenshot_bmp.py
+++ b/tests/test_screenshot_bmp.py
@@ -1,0 +1,64 @@
+# Unit tests for the BMP encoder behind save_screenshot_bmp()
+import struct
+import sys
+import unittest
+
+sys.path.insert(0, "lib")
+from mpos.ui.testing import encode_bmp
+
+HEADER_SIZE = 54
+
+
+def make_pixels(width, height):
+    """Build an LVGL RGB888 buffer (blue, green, red per pixel)."""
+    buf = bytearray(width * height * 3)
+    for y in range(height):
+        for x in range(width):
+            i = (y * width + x) * 3
+            buf[i] = x * 3          # blue
+            buf[i + 1] = y * 5      # green
+            buf[i + 2] = 200 - x    # red
+    return buf
+
+
+class TestEncodeBmp(unittest.TestCase):
+
+    def test_header_describes_the_image(self):
+        width, height = 8, 3
+        bmp = encode_bmp(make_pixels(width, height), width, height)
+        self.assertEqual(bmp[0:2], b"BM")
+        self.assertEqual(struct.unpack("<I", bmp[2:6])[0], len(bmp))
+        self.assertEqual(struct.unpack("<I", bmp[10:14])[0], HEADER_SIZE)
+        self.assertEqual(struct.unpack("<I", bmp[14:18])[0], 40)
+        self.assertEqual(struct.unpack("<I", bmp[18:22])[0], width)
+        self.assertEqual(struct.unpack("<i", bmp[22:26])[0], -height)  # top-down
+        self.assertEqual(struct.unpack("<H", bmp[26:28])[0], 1)
+        self.assertEqual(struct.unpack("<H", bmp[28:30])[0], 24)
+        self.assertEqual(struct.unpack("<I", bmp[34:38])[0], len(bmp) - HEADER_SIZE)
+
+    def test_rows_are_copied_when_they_need_no_padding(self):
+        width, height = 8, 3  # 24 bytes per row, already a multiple of 4
+        pixels = make_pixels(width, height)
+        bmp = encode_bmp(pixels, width, height)
+        self.assertEqual(len(bmp), HEADER_SIZE + width * height * 3)
+        self.assertEqual(bytes(bmp[HEADER_SIZE:]), bytes(pixels))
+
+    def test_rows_are_padded_to_four_bytes(self):
+        width, height = 3, 2  # 9 bytes per row, padded to 12
+        pixels = make_pixels(width, height)
+        bmp = encode_bmp(pixels, width, height)
+        stride = 12
+        self.assertEqual(len(bmp), HEADER_SIZE + stride * height)
+        for y in range(height):
+            row = bmp[HEADER_SIZE + y * stride:HEADER_SIZE + (y + 1) * stride]
+            self.assertEqual(bytes(row[:width * 3]), bytes(pixels[y * width * 3:(y + 1) * width * 3]))
+            self.assertEqual(bytes(row[width * 3:]), b"\x00" * (stride - width * 3))
+
+    def test_a_screen_sized_image_has_the_expected_size(self):
+        width, height = 320, 240
+        bmp = encode_bmp(bytearray(width * height * 3), width, height)
+        self.assertEqual(len(bmp), HEADER_SIZE + width * height * 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a hotkey to SDL to make a screenshot from the current app. This captures the actual pixels, not the scaled version. 

We re-used the BMP code that the web server already had and moved that into a shared function (`mpos.ui.testing.encode_bmp()`), instead of copying the BMP write code.

So CTRL-SHIFT-S (CMD-SHIFT-S on macOS) saves screenshot-YYYYMMDD-HHMMSS.bmp in the `internal_filesystem` directory and prints the absolute path.

This is for your consideration; if you want a different shortcut key, let me know and I can change it.