### PR TITLE
Cache emoji codepoints for keyboard input

### DIFF
--- a/internal_filesystem/lib/mpos/ui/font_manager.py
+++ b/internal_filesystem/lib/mpos/ui/font_manager.py
@@ -22,6 +22,8 @@ class FontManager:
     # probes, and repeated per-codepoint fallback walks.
     _emoji_map = None  # dict of hex-key -> src path, populated on first use
     _emoji_strings = None  # list of complete emoji strings, populated on first use
+    _emoji_codepoints = None
+    _emoji_codepoints_sorted = None
     _builtin_font_records = None
     _composed_font_cache = {}
     _ttf_font_cache = {}
@@ -276,14 +278,12 @@ lips,🫦
     @classmethod
     def getEmojiCodepoints(cls):
         cls._ensure_emoji_map()
-        all_cps = set()
-        for key in cls._emoji_map:
-            try:
-                cp = int(key.split("-")[0], 16)
-                all_cps.add(cp)
-            except Exception:
-                pass
-        return sorted(all_cps)
+        return list(cls._emoji_codepoints_sorted)
+
+    @classmethod
+    def isEmojiCodepoint(cls, codepoint):
+        cls._ensure_emoji_map()
+        return codepoint in cls._emoji_codepoints
 
     @classmethod
     def getEmojiStrings(cls):
@@ -329,32 +329,30 @@ lips,🫦
         Falls back to a safe wide range if no emojis are loaded yet."""
         if cls._emoji_cp_bounds is not None:
             return cls._emoji_cp_bounds
-        lo = None
-        hi = None
-        for key in cls._emoji_map or {}:
-            try:
-                cp = int(key.split("-")[0], 16)
-            except Exception:
-                continue
-            if lo is None or cp < lo: lo = cp
-            if hi is None or cp > hi: hi = cp
-        if lo is None:
+        cls._ensure_emoji_map()
+        if not cls._emoji_codepoints:
             # No emojis loaded — accept everything so behaviour matches the
             # unpatched code path. Caller should re-create the font once
             # the map is populated.
             return (0, 0xFFFFFFFF)
-        cls._emoji_cp_bounds = (lo, hi)
+        cls._emoji_cp_bounds = (min(cls._emoji_codepoints), max(cls._emoji_codepoints))
         return cls._emoji_cp_bounds
 
     @classmethod
     def _ensure_emoji_map(cls):
         if cls._emoji_map is None:
-            cls._emoji_map = cls._build_emoji_map()
+            (
+                cls._emoji_map,
+                cls._emoji_strings,
+                cls._emoji_codepoints,
+                cls._emoji_codepoints_sorted,
+            ) = cls._build_emoji_map()
 
     @classmethod
     def _build_emoji_map(cls):
         emoji_map = {}
         emoji_strings = set()
+        emoji_codepoints = set()
 
         entries = cls._list_dir_names(_EMOJI_DIR_PATH)
         if entries is None:
@@ -363,8 +361,7 @@ lips,🫦
             except Exception:
                 cwd = "?"
             logger.warning("could not list emoji dir '%s' (cwd=%s)", _EMOJI_DIR_PATH, cwd)
-            cls._emoji_strings = []
-            return emoji_map
+            return emoji_map, [], emoji_codepoints, []
 
         for name in entries:
             if not name.lower().endswith(".png"):
@@ -372,23 +369,20 @@ lips,🫦
 
             name_without_ext = name[:-4]
             segments = name_without_ext.split("-")
-            valid = True
-            for seg in segments:
-                try:
-                    int(seg, 16)
-                except Exception:
-                    valid = False
-                    break
-            if not valid:
+            try:
+                codepoints = [int(seg, 16) for seg in segments]
+            except Exception:
                 logger.warning("skip non-hex emoji file: %s", name)
                 continue
 
             # Build the full renderable emoji string (e.g. flag sequences, variation selectors).
             try:
-                emoji_string = "".join(chr(int(seg, 16)) for seg in segments)
+                emoji_string = "".join(chr(codepoint) for codepoint in codepoints)
                 emoji_strings.add(emoji_string)
             except Exception:
                 pass
+
+            emoji_codepoints.add(codepoints[0])
 
             base_key = segments[0].upper()
             full_key = name_without_ext.upper()
@@ -402,8 +396,7 @@ lips,🫦
                 emoji_map[base_key] = _EMOJI_SRC_PREFIX + name
 
         if __debug__: logger.debug("loaded %s emoji png mappings from %s", len(emoji_map), _EMOJI_DIR_PATH)
-        cls._emoji_strings = sorted(emoji_strings)
-        return emoji_map
+        return emoji_map, sorted(emoji_strings), emoji_codepoints, sorted(emoji_codepoints)
 
     @classmethod
     def _get_emoji_src(cls, codepoint, target_height):

--- a/internal_filesystem/lib/mpos/ui/keyboard.py
+++ b/internal_filesystem/lib/mpos/ui/keyboard.py
@@ -310,12 +310,8 @@ class MposKeyboard:
         if not text:
             return False
 
-        emoji_codepoints = FontManager.getEmojiCodepoints()
-        if not emoji_codepoints:
-            return False
-
         for char in text:
-            if ord(char) in emoji_codepoints:
+            if FontManager.isEmojiCodepoint(ord(char)):
                 return True
         return False
 

--- a/tests/test_graphical_font_manager.py
+++ b/tests/test_graphical_font_manager.py
@@ -27,6 +27,8 @@ def _reset_font_manager():
     FontManager._ttf_font_cache.clear()
     FontManager._emoji_map = None
     FontManager._emoji_strings = None
+    FontManager._emoji_codepoints = None
+    FontManager._emoji_codepoints_sorted = None
     FontManager._emoji_src_lookup_cache.clear()
     FontManager._emoji_sequence_lookup_cache.clear()
     FontManager._imgfont_scaled_src_cache.clear()
@@ -241,6 +243,16 @@ class TestFontManagerEmojiCodepoints(GraphicalTestCase):
         for cp in FontManager.getEmojiCodepoints():
             self.assertTrue(cp >= 0x100, "Codepoint should not be plain ASCII")
             self.assertTrue(cp <= 0x10FFFF, "Codepoint should be within Unicode range")
+
+    def test_isemoji_codepoint_identifies_available_emoji(self):
+        self.assertTrue(FontManager.isEmojiCodepoint(ord("😀")))
+        self.assertFalse(FontManager.isEmojiCodepoint(ord("A")))
+
+    def test_isemoji_codepoint_reuses_cached_index(self):
+        FontManager.isEmojiCodepoint(ord("😀"))
+        codepoints = FontManager._emoji_codepoints
+        FontManager.isEmojiCodepoint(ord("A"))
+        self.assertIs(FontManager._emoji_codepoints, codepoints)
 
     def test_emoji_tier_loaded_after_getemoji(self):
         """After getEmojiCodepoints(), the 32x32 tier is populated."""


### PR DESCRIPTION
This PR avoids rebuilding the emoji codepoint set on every regular keyboard input.

Previously, `MposKeyboard._contains_emoji()` called `FontManager.getEmojiCodepoints()` for every character until the user entered their first emoji. That method walked the full emoji map, split and parsed every key, built a set, and sorted it into a list every time you pressed a key.

We added `FontManager.isEmojiCodepoint()` for the keyboard hot path. This checks the cached set directly, so regular keyboard input now does one `ord()` and one set lookup without rebuilding any collections. `getEmojiCodepoints()` still returns a new sorted list, preserving its existing API. The emoji codepoint bounds calculation also reuses the cached set instead of parsing the map keys again.

I added tests that cover identifying available emoji, rejecting regular characters, and reusing the same cached codepoint index across calls.