### PR TITLE
AppStore: resolve QR deep links to local apps before the index download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Board Support:
 
 Builtin Apps:
 - AppStore: add "Scan QR" button that opens an app's detail screen from a scanned app link (https://apps.micropythonos.com/app/APP_ID, micropythonos://app/APP_ID or mpos://app/APP_ID)
+- AppStore: open a QR deep link's app detail screen immediately when the app is already known locally, instead of waiting for the index download
 - AppStore and OSUpdate: fix cooldown blocking the first update check for 60s after boot on ESP32 (ticks_ms counts from boot)
 
 Frameworks:

--- a/internal_filesystem/builtin/apps/com.micropythonos.appstore/appstore.py
+++ b/internal_filesystem/builtin/apps/com.micropythonos.appstore/appstore.py
@@ -436,6 +436,11 @@ class AppStore(Activity):
         self.create_apps_list()
         self._update_category_dropdown()
 
+        # A deep link to an app that is already known locally (e.g. installed)
+        # can open its detail screen right now, without waiting for the index
+        # download. Unknown apps keep waiting for Phase 2.
+        self._try_early_deeplink()
+
         # Phase 2: download store index and merge in new apps
         try:
             response = await DownloadManager.download_url(json_url)
@@ -907,6 +912,16 @@ class AppStore(Activity):
             if app.fullname == fullname:
                 return app
         return None
+
+    def _try_early_deeplink(self):
+        """Open a pending deep link now if the app is already resolvable."""
+        fullname = getattr(self, "_pending_deeplink", None)
+        if not fullname:
+            return
+        app = self._find_store_app(fullname)
+        if app:
+            self._pending_deeplink = None
+            self.show_app_detail(app)
 
     def _resolve_pending_deeplink(self, index_available=True):
         fullname = getattr(self, "_pending_deeplink", None)

--- a/tests/test_graphical_appstore_scanqr.py
+++ b/tests/test_graphical_appstore_scanqr.py
@@ -22,7 +22,6 @@ import unittest
 
 import lvgl as lv
 
-import mpos
 from mpos import AppManager, DownloadManager, Intent, TaskManager
 from mpos.ui import QR_SYMBOL
 from mpos.ui.testing import find_label_with_text, wait_for_render
@@ -137,6 +136,27 @@ class TestGraphicalAppStoreScanQR(unittest.TestCase):
         # Index refresh fails (stubbed offline), so the "No connection" dialog shows.
         label = find_label_with_text(lv.layer_top(), "No connection")
         self.assertIsNotNone(label, "unknown app with no index should show the 'No connection' dialog")
+
+    def test_deeplink_to_installed_app_resolves_before_index_download(self):
+        # A deep link to an installed app must open its detail screen from
+        # phase 1 (local app list) alone — by the time the index download
+        # starts, the pending deep link should already be consumed.
+        pending_at_download = []
+
+        async def _recording_download(url, **kwargs):
+            import mpos.ui
+            for entry in mpos.ui.screen_stack:
+                activity = entry[0]
+                if activity.__class__.__name__ == "AppStore":
+                    pending_at_download.append(activity._pending_deeplink)
+            raise OSError("no network in test")
+        DownloadManager.download_url = staticmethod(_recording_download)
+
+        intent = Intent(extras={"deeplink_fullname": HELLOWORLD})
+        self._start_appstore(intent=intent)
+        self.assertIsNotNone(find_label_with_text(lv.screen_active(), "HelloWorld"))
+        self.assertEqual(pending_at_download, [None],
+                         "deep link should be resolved before the index download runs")
 
     def test_deeplink_intent_opens_detail(self):
         intent = Intent(extras={"deeplink_fullname": HELLOWORLD})


### PR DESCRIPTION
Follow-up to #249 from real-device testing of the QR flow on an ESP32-S3 badge.

**Observed on hardware:** scanning an app QR in the Camera app and tapping "Open in App Store" opened the store's list screen, then sat on "Downloading app index..." until the catalog download finished — only then did the app's detail screen appear. On device WiFi that's a noticeable, awkward pause.

**Fix:** Phase 1 of `download_app_index` (the local, instant listing of installed apps) already knows every installed app, so a pending deep link that matches one now opens its detail screen right after Phase 1 — the index download continues in the background as before. Deep links to apps *not* known locally keep the existing behavior (resolved after Phase 2, with the existing not-found / no-connection dialogs).

**Testing:**
- New desktop test asserts the ordering precisely: by the time the (stubbed) index download is invoked, a deep link to an installed app has already been consumed and its detail screen is open. Full scan-QR suite: 7/7 green.
- Verified on the physical badge: camera scan → chip → detail screen now appears immediately after the store's first paint.

Also from the on-device session, for the record: `tests/test_deeplink.py` passes 35/35 on hardware, and the scan button renders correctly on the device's App Store top bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)