### PR TITLE
Fix test tooling: long-press simulation and click_button targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ OS:
 - sdl_keyboard: CTRL-SHIFT-S (CMD-SHIFT-S on macOS) saves a timestamped BMP screenshot in the current directory, at the screen's own pixel size instead of the scaled SDL window
 
 Testing:
+- mpos.ui.testing: simulate_click() now pumps simulated-indev reads during the press hold, so LONG_PRESSED fires even when nothing else runs the LVGL loop during the sleep (e.g. MPOSController.long_press() exec'd via aiorepl, which blocks the scheduler)
+- mpos_controller: click_button() now clicks the innermost clickable widget containing the labelled text instead of the outermost clickable ancestor (often the screen itself), which sent clicks to the screen center for nested labels
 - tests: eliminate all direct lv.task_handler() calls from the topmenu drawer test; wait_ms now uses pure time.sleep() instead of a tight lv.task_handler() polling loop, preventing an unrecoverable hang when SDL event polling blocks on macOS ARM CI after many process cycles
 - topmenu drawer test: use animate=False for all close_drawer() calls; close_drawer() now accepts an animate parameter matching the existing close_bar() API
 - test_runner: disable notification sound on macOS/darwin in the settings because it causes a hang on the headless (soundcardless?) macOS CI runners

--- a/internal_filesystem/lib/mpos/ui/testing.py
+++ b/internal_filesystem/lib/mpos/ui/testing.py
@@ -1235,8 +1235,15 @@ def simulate_click(x, y, press_duration_ms=100):
     time.sleep(0.02)
     _touch_indev.read()
 
-    # Wait for press duration
-    time.sleep(press_duration_ms / 1000.0)
+    # Wait for press duration, pumping indev reads so LVGL sees a sustained
+    # press. Without these reads LONG_PRESSED never fires in contexts where
+    # nothing else runs the LVGL loop during the sleep (e.g. aiorepl exec).
+    remaining_ms = press_duration_ms
+    while remaining_ms > 0:
+        step_ms = min(20, remaining_ms)
+        time.sleep(step_ms / 1000.0)
+        _touch_indev.read()
+        remaining_ms -= step_ms
 
     # Release the touch
     _touch_pressed = False

--- a/scripts/mpos_controller.py
+++ b/scripts/mpos_controller.py
@@ -306,6 +306,31 @@ def _widget_matches(widget, type=None, text=None, clickable=None):
     return True
 
 
+def _find_clickable_by_text(tree, text):
+    """Find the innermost clickable widget whose own text or descendant label
+    text matches *text*.
+
+    Walking outermost-first would return a clickable ancestor (screens and
+    plain containers are clickable by default) whose center may not even be
+    over the labelled widget, so the click would land on a sibling.
+    """
+    def walk(nodes, ancestors):
+        if not isinstance(nodes, list):
+            return None
+        for widget in nodes:
+            path = ancestors + [widget]
+            if widget.get("text") == text:
+                for candidate in reversed(path):
+                    if candidate.get("clickable"):
+                        return candidate
+            found = walk(widget.get("children"), path)
+            if found is not None:
+                return found
+        return None
+
+    return walk(tree, [])
+
+
 # ── Stream ──────────────────────────────────────────────────────────
 
 class _PTYStream:
@@ -947,17 +972,8 @@ for i in range(steps + 1):
         self.press(widget["center_x"], widget["center_y"])
 
     def _find_button_by_text(self, tree, text):
-        """Find a clickable widget whose own text or child label text matches."""
-        for widget, _parent in _find_widgets(
-            tree, lambda w: _widget_matches(w, clickable=True)
-        ):
-            if widget.get("text") == text:
-                return widget
-            for child, _p in _find_widgets(
-                widget.get("children", []), lambda w: w.get("text") == text
-            ):
-                return widget
-        return None
+        """Find the innermost clickable widget whose own text or child label text matches."""
+        return _find_clickable_by_text(tree, text)
 
     def wait_for_text(self, text, timeout=10, disappear=False):
         """Wait until *text* appears (or disappears) on screen. Returns True on success."""
@@ -1372,17 +1388,8 @@ class SerialBackend:
         self.press(widget["center_x"], widget["center_y"])
 
     def _find_button_by_text(self, tree, text):
-        """Find a clickable widget whose own text or child label text matches."""
-        for widget, _parent in _find_widgets(
-            tree, lambda w: _widget_matches(w, clickable=True)
-        ):
-            if widget.get("text") == text:
-                return widget
-            for child, _p in _find_widgets(
-                widget.get("children", []), lambda w: w.get("text") == text
-            ):
-                return widget
-        return None
+        """Find the innermost clickable widget whose own text or child label text matches."""
+        return _find_clickable_by_text(tree, text)
 
     def wait_for_text(self, text, timeout=10, disappear=False):
         """Wait until *text* appears (or disappears) on screen. Returns True on success."""

--- a/tests/cpython_mpos_controller.py
+++ b/tests/cpython_mpos_controller.py
@@ -456,6 +456,54 @@ btn.add_event_cb(cb, lv.EVENT.CLICKED, None)
     except ImportError:
         check(True, "screenshot_image skipped (pillow not installed)")
 
+    # click_button must click the labelled widget's own button, not a clickable
+    # ancestor (screens and plain containers are clickable by default). The
+    # nested button sits away from the container center so the old
+    # outermost-first match would miss it.
+    mpos.exec("""
+import lvgl as lv
+scr = lv.obj()
+lv.screen_load(scr)
+cont = lv.obj(scr)
+cont.set_size(300, 220)
+cont.center()
+nbtn = lv.button(cont)
+nbtn.set_size(120, 40)
+nbtn.align(lv.ALIGN.BOTTOM_RIGHT, 0, 0)
+lv.label(nbtn).set_text("Nested Button")
+nstatus = lv.label(cont)
+nstatus.set_text("nested idle")
+nstatus.align(lv.ALIGN.TOP_MID, 0, 0)
+nbtn.add_event_cb(lambda e: nstatus.set_text("nested clicked"), lv.EVENT.CLICKED, None)
+""")
+    time.sleep(0.3)
+    mpos.click_button("Nested Button")
+    check(
+        mpos.wait_for_text("nested clicked", timeout=5),
+        "click_button clicks innermost clickable for nested labels",
+    )
+
+    # long_press must deliver LONG_PRESSED. The simulated indev has to keep
+    # reporting the pressed state during the hold, because nothing else runs
+    # the LVGL loop while an exec'd sleep blocks the aiorepl task.
+    mpos.exec("""
+import lvgl as lv
+scr2 = lv.obj()
+lv.screen_load(scr2)
+lbtn = lv.button(scr2)
+lbtn.set_size(120, 50)
+lbtn.center()
+lv.label(lbtn).set_text("LP Button")
+lstatus = lv.label(scr2)
+lstatus.set_text("lp idle")
+lstatus.align(lv.ALIGN.TOP_MID, 0, 10)
+lbtn.add_event_cb(lambda e: lstatus.set_text("lp fired"), lv.EVENT.LONG_PRESSED, None)
+""")
+    time.sleep(0.3)
+    lp_btn = mpos.find_widget(type="button")
+    mpos.long_press(lp_btn["center_x"], lp_btn["center_y"])
+    check(mpos.wait_for_text("lp fired", timeout=5), "long_press delivers LONG_PRESSED")
+
 
 def test_app_management(mpos, is_serial=False, cli_binary=None, serial_port=None):
     section("App management (install / list / remove)")

--- a/tests/test_graphical_simulate_long_press.py
+++ b/tests/test_graphical_simulate_long_press.py
@@ -1,0 +1,68 @@
+"""
+Graphical test for the simulate_long_press() testing helper.
+
+A long press must deliver LV_EVENT_LONG_PRESSED to the pressed widget,
+which requires the simulated touch indev to keep reporting the pressed
+state for the whole press duration. A short click must NOT deliver
+LONG_PRESSED.
+"""
+
+import unittest
+
+import lvgl as lv
+
+from mpos import simulate_click, simulate_long_press, wait_for_render
+
+
+class TestGraphicalSimulateLongPress(unittest.TestCase):
+
+    def setUp(self):
+        self.events = []
+        self.screen = lv.obj()
+        lv.screen_load(self.screen)
+
+        self.button = lv.button(self.screen)
+        self.button.set_size(120, 60)
+        self.button.align(lv.ALIGN.CENTER, 0, 0)
+        label = lv.label(self.button)
+        label.set_text("Hold me")
+        label.center()
+
+        self.button.add_event_cb(
+            lambda e: self.events.append("long_pressed"), lv.EVENT.LONG_PRESSED, None
+        )
+        self.button.add_event_cb(
+            lambda e: self.events.append("short_clicked"), lv.EVENT.SHORT_CLICKED, None
+        )
+        wait_for_render()
+
+    def _button_center(self):
+        area = lv.area_t()
+        self.button.get_coords(area)
+        return (area.x1 + area.x2) // 2, (area.y1 + area.y2) // 2
+
+    def test_long_press_fires_long_pressed(self):
+        x, y = self._button_center()
+        simulate_long_press(x, y)
+        wait_for_render()
+        self.assertTrue(
+            "long_pressed" in self.events,
+            "simulate_long_press did not deliver LONG_PRESSED, got: %s" % self.events,
+        )
+
+    def test_short_click_does_not_fire_long_pressed(self):
+        x, y = self._button_center()
+        simulate_click(x, y)
+        wait_for_render()
+        self.assertTrue(
+            "long_pressed" not in self.events,
+            "short click unexpectedly delivered LONG_PRESSED, got: %s" % self.events,
+        )
+        self.assertTrue(
+            "short_clicked" in self.events,
+            "short click did not deliver SHORT_CLICKED, got: %s" % self.events,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two bugs in the test tooling, found while driving an app through MPOSController.

## 1. `simulate_long_press()` never delivers `LONG_PRESSED` from aiorepl contexts

`simulate_click()` only read the simulated touch indev at press and at release, never during the hold. LVGL only detects a long press from reads that happen *while* the press is held, so in contexts where nothing else runs the LVGL loop during the sleep — e.g. code exec'd via aiorepl, which blocks the scheduler — `LONG_PRESSED` never fired and `MPOSController.long_press()` silently behaved like a plain click.

Fix: pump `_touch_indev.read()` every 20 ms during the hold. The default 100 ms click stays well under the 400 ms long-press threshold, so existing `simulate_click()` users are unaffected (verified by running the existing graphical tests that use it).

## 2. `MPOSController.click_button()` clicks the wrong widget for nested labels

`_find_button_by_text()` walked the tree outermost-first and matched a label through *any* clickable ancestor. Screens and plain containers are clickable by default, so for any deeply nested label the screen root matched first and the click landed at the screen center — on whatever widget happened to be there. (Concretely: `click_button("X")` on a grid of buttons pressed a different button than the one labelled "X".)

Fix: resolve to the innermost clickable ancestor of the matching label. Also deduplicates the helper, which was copy-pasted identically in both backends.

## Tests

- New graphical test `tests/test_graphical_simulate_long_press.py` (LONG_PRESSED delivered on long press, not on short click).
- Two regression checks added to `tests/cpython_mpos_controller.py`: nested-label `click_button()` targeting, and `long_press()` delivering `LONG_PRESSED`. The nested-click check fails before the fix and passes after. Note: the `long_press` check exercises the *frozen* `mpos` lib when the desktop binary freezes `/lib`, so it needs a binary built from a commit that includes this fix; I verified the fixed function against a live process by injecting it, since my local macOS SDL2 build is currently broken for unrelated SDK reasons.

## Merge checklist

- CHANGELOG.md: entries added under Testing in "Future release".
- No app manifests, docs, or board list affected; no settings migrations needed.
- Functional changes only; no formatting-only commits mixed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
