### PR TITLE
SharedPreferences: return copies from get_dict_item and get_list_item_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Frameworks:
 - FontManager: stop leaking an app's TTF and emoji fonts after the app closes by @fdb
 - FontManager: cache emoji codepoints for keyboard input by @fdb
 - Screenshot: move the BMP encoder out of the web server into mpos.ui.testing.encode_bmp(), which both now share, and add save_screenshot_bmp() to capture the screen straight into a file
+- SharedPreferences: get_dict_item() and get_list_item_dict() now return copies like get_dict()/get_list() already did, so mutating a returned item no longer corrupts prefs.data in place — which made a following put+commit of that item look like a no-op, silently skipping the write and losing the change on the next load
 - TaskManager: add create_supervised_task(restart_on_return=True) and use it for the aiorepl console, so it is restarted when it exits
 - TaskManager: create_task returns None when the task manager is disabled, preventing C-level crashes from asyncio.create_task on ESP32 when called from a disabled test runner context
 - View: clear the shared default focus group before the screen is deleted to prevent dangling LVGL pointer accumulation across activity transitions

--- a/internal_filesystem/lib/mpos/shared_preferences.py
+++ b/internal_filesystem/lib/mpos/shared_preferences.py
@@ -246,9 +246,12 @@ class SharedPreferences:
     def get_list_item_dict(self, list_key, index, default=None):
         """Retrieve an entire dictionary from a list at the specified index."""
         try:
-            return self.data.get(list_key, [])[index]
+            item = self.data.get(list_key, [])[index]
         except (IndexError, TypeError):
             return default if default is not None else {}
+        if isinstance(item, dict):
+            return dict(item)  # return a copy — callers must not mutate prefs.data directly
+        return item
 
     # Generic methods for dictionary-based structures
     def get_dict_item_field(self, dict_key, item_key, field, default=None):
@@ -261,9 +264,12 @@ class SharedPreferences:
     def get_dict_item(self, dict_key, item_key, default=None):
         """Retrieve the entire configuration for an item in a dictionary by item_key."""
         try:
-            return self.data.get(dict_key, {}).get(item_key, default if default is not None else {})
+            item = self.data.get(dict_key, {}).get(item_key, default if default is not None else {})
         except (KeyError, TypeError):
             return default if default is not None else {}
+        if isinstance(item, dict):
+            return dict(item)  # return a copy — callers must not mutate prefs.data directly
+        return item
 
     def get_dict_keys(self, dict_key):
         """Retrieve a list of all keys in a dictionary at dict_key."""

--- a/tests/test_shared_preferences.py
+++ b/tests/test_shared_preferences.py
@@ -276,6 +276,47 @@ class TestSharedPreferences(unittest.TestCase):
         self.assertEqual(theme["color"], "blue")
         self.assertEqual(prefs.get_dict_item("settings", "nonexistent"), {})
 
+    def test_get_dict_item_returns_copy(self):
+        """Mutating a returned dict item must not change the stored data."""
+        prefs = SharedPreferences(self.test_app_name)
+        prefs.edit().put_dict_item("buttons", "b1", {"name": "one"}).commit()
+
+        item = prefs.get_dict_item("buttons", "b1")
+        item["name"] = "mutated"
+        item["extra"] = True
+
+        self.assertEqual(prefs.get_dict_item("buttons", "b1"), {"name": "one"})
+
+    def test_get_list_item_dict_returns_copy(self):
+        """Mutating a returned list item must not change the stored data."""
+        prefs = SharedPreferences(self.test_app_name)
+        prefs.edit().put_list("configs", [{"key": "value"}]).commit()
+
+        item = prefs.get_list_item_dict("configs", 0)
+        item["key"] = "mutated"
+
+        self.assertEqual(prefs.get_list_item_dict("configs", 0), {"key": "value"})
+
+    def test_mutated_dict_item_still_persists_on_commit(self):
+        """Get-mutate-put of a dict item must be written to disk.
+
+        When get_dict_item returned the live nested dict, mutating it made
+        the later commit look like a no-op (temp_data compared equal to the
+        already-mutated prefs.data), so nothing was written and the change
+        was lost on the next load.
+        """
+        prefs = SharedPreferences(self.test_app_name)
+        prefs.edit().put_dict_item("buttons", "b1", {"name": "one"}).commit()
+
+        config = prefs.get_dict_item("buttons", "b1")
+        config["loop"] = True
+        prefs.edit().put_dict_item("buttons", "b1", config).commit()
+
+        reloaded = SharedPreferences(self.test_app_name)
+        self.assertEqual(
+            reloaded.get_dict_item("buttons", "b1"), {"name": "one", "loop": True}
+        )
+
     def test_get_dict_item_field(self):
         """Test getting a specific field from a dict item."""
         prefs = SharedPreferences(self.test_app_name)


### PR DESCRIPTION
## The bug

`get_dict()` and `get_list()` deliberately return copies ("callers must not mutate prefs.data directly"), but the per-item getters `get_dict_item()` and `get_list_item_dict()` returned the **live nested dict** from `self.data`.

A caller following the natural get→mutate→put→commit pattern:

```python
config = prefs.get_dict_item("buttons", "b1")
config["loop"] = True
prefs.edit().put_dict_item("buttons", "b1", config).commit()
```

silently loses the change: mutating the returned dict already mutated `prefs.data` in place, so `Editor.commit()`'s no-op write guard sees `filtered_data == self.preferences.data`, skips the write, and the change evaporates on the next `load()`. In-memory state looks correct the whole time, which makes this painful to diagnose.

This bit the ClipTV app in practice — the first assignment to a button persisted (fresh dict from the missing-key default), but every subsequent edit to the same button was lost after a prefs reload.

## The fix

Return shallow copies from `get_dict_item()` and `get_list_item_dict()`, matching the existing `get_dict()`/`get_list()` convention. Non-dict items (unusual, but previously passed through) are still returned unchanged. No in-tree caller relied on the live reference (grep: the only references are in `shared_preferences.py` itself and its tests).

## Tests

Three new regression tests in `tests/test_shared_preferences.py`:
- mutating a returned dict item does not change stored data
- mutating a returned list item dict does not change stored data
- the full get→mutate→put→commit→reload scenario persists correctly

Before the fix exactly these 3 fail and the other 58 pass; after the fix all 61 pass.

Note on how they were verified: on a desktop binary with the lib frozen at `-O3`, `unittest` loads from the frozen lib with `assert` statements stripped, so `scripts/test_runner.py` reports assertion-based tests as vacuously green. These results were obtained with a direct import-based run against the filesystem lib (`sys.path.insert(0, 'lib')` before anything imports `unittest`). A separate PR adds a self-check to the test runner for that trap.

## Merge checklist

- CHANGELOG.md: entry added under Frameworks in "Future release".
- No manifests/docs/boards affected; no settings migration needed (stored data format unchanged).
- Functional change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
