### PR TITLE
test tooling: fail loudly when unittest assertions are stripped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ OS:
 - sdl_keyboard: CTRL-SHIFT-S (CMD-SHIFT-S on macOS) saves a timestamped BMP screenshot in the current directory, at the screen's own pixel size instead of the scaled SDL window
 
 Testing:
-- test_runner/mpos_controller: self-check that unittest assertions actually raise before running a suite, and fail the run with a clear diagnostic when unittest resolves to a build with assert statements stripped (mpy-cross -O3, e.g. the frozen lib of a prod firmware) — previously every assertion was a silent no-op and whole suites reported vacuously green
+- test_runner/mpos_controller: self-check that unittest assertions actually raise before running a suite; when boot cached a stripped copy (mpy-cross -O3, e.g. a frozen lib imported before lib/ is on sys.path), repair it by grafting the working assert methods from the filesystem lib/unittest, and only fail the run with a clear diagnostic when no working unittest is available — previously every assertion was a silent no-op and whole suites reported vacuously green
+- mpos_controller: write paste-mode payloads in chunks, draining the echoed input between chunks — a large payload written in one call deadlocked once payload plus echo filled the PTY buffers, hanging exec() until timeout
 - tests: eliminate all direct lv.task_handler() calls from the topmenu drawer test; wait_ms now uses pure time.sleep() instead of a tight lv.task_handler() polling loop, preventing an unrecoverable hang when SDL event polling blocks on macOS ARM CI after many process cycles
 - topmenu drawer test: use animate=False for all close_drawer() calls; close_drawer() now accepts an animate parameter matching the existing close_bar() API
 - test_runner: disable notification sound on macOS/darwin in the settings because it causes a hang on the headless (soundcardless?) macOS CI runners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ OS:
 - sdl_keyboard: CTRL-SHIFT-S (CMD-SHIFT-S on macOS) saves a timestamped BMP screenshot in the current directory, at the screen's own pixel size instead of the scaled SDL window
 
 Testing:
+- test_runner/mpos_controller: self-check that unittest assertions actually raise before running a suite, and fail the run with a clear diagnostic when unittest resolves to a build with assert statements stripped (mpy-cross -O3, e.g. the frozen lib of a prod firmware) — previously every assertion was a silent no-op and whole suites reported vacuously green
 - tests: eliminate all direct lv.task_handler() calls from the topmenu drawer test; wait_ms now uses pure time.sleep() instead of a tight lv.task_handler() polling loop, preventing an unrecoverable hang when SDL event polling blocks on macOS ARM CI after many process cycles
 - topmenu drawer test: use animate=False for all close_drawer() calls; close_drawer() now accepts an animate parameter matching the existing close_bar() API
 - test_runner: disable notification sound on macOS/darwin in the settings because it causes a hang on the headless (soundcardless?) macOS CI runners

--- a/scripts/mpos_controller.py
+++ b/scripts/mpos_controller.py
@@ -96,24 +96,52 @@ def _count_usb_serial_devices():
 
 # Self-check pasted into every test run right after `import unittest`.
 # unittest's assert methods are plain `assert` statements, which
-# mpy-cross -O3 strips. When unittest resolves to such a build (e.g. the
-# frozen lib of a prod firmware, already imported at boot before lib/ is
-# prepended to sys.path), every assertion is a silent no-op and the whole
-# suite reports vacuously green. Abort loudly instead of "passing".
+# mpy-cross -O3 strips. When unittest resolves to such a build (e.g. a
+# frozen copy already imported at boot, before lib/ is prepended to
+# sys.path), every assertion is a silent no-op and the whole suite
+# reports vacuously green.
+#
+# When that happens, try to self-heal: import the filesystem
+# lib/unittest (sys.path has lib/ first here) and graft its working
+# assert methods onto the cached module's TestCase, so classes that
+# already subclassed it (e.g. GraphicalTestCase) are repaired too.
+# Only when no working unittest is available does the run abort loudly
+# instead of "passing".
 _ASSERT_SELF_CHECK_CODE = (
-    "try:\n"
-    "    unittest.TestCase().assertTrue(False)\n"
-    "    _mpos_asserts_work = False\n"
-    "except AssertionError:\n"
-    "    _mpos_asserts_work = True\n"
+    "def _mpos_asserts_ok(_ut):\n"
+    "    try:\n"
+    "        _ut.TestCase().assertTrue(False)\n"
+    "        return False\n"
+    "    except AssertionError:\n"
+    "        return True\n"
+    "_mpos_asserts_work = _mpos_asserts_ok(unittest)\n"
+    "if not _mpos_asserts_work:\n"
+    "    _mpos_stripped_ut = sys.modules.pop('unittest', None)\n"
+    "    try:\n"
+    "        import unittest as _mpos_fresh_ut\n"
+    "    except ImportError:\n"
+    "        _mpos_fresh_ut = None\n"
+    "    if _mpos_stripped_ut is not None:\n"
+    "        sys.modules['unittest'] = _mpos_stripped_ut\n"
+    "    if (_mpos_fresh_ut is not None\n"
+    "            and _mpos_fresh_ut is not _mpos_stripped_ut\n"
+    "            and _mpos_asserts_ok(_mpos_fresh_ut)):\n"
+    "        for _mpos_name in dir(_mpos_fresh_ut.TestCase):\n"
+    "            if _mpos_name.startswith('assert'):\n"
+    "                setattr(_mpos_stripped_ut.TestCase, _mpos_name,\n"
+    "                        getattr(_mpos_fresh_ut.TestCase, _mpos_name))\n"
+    "        _mpos_asserts_work = _mpos_asserts_ok(unittest)\n"
+    "        if _mpos_asserts_work:\n"
+    "            print('MPOS_TEST_RUNNER: repaired stripped unittest assert "
+    "methods using lib/unittest')\n"
     "if not _mpos_asserts_work:\n"
     "    print("
     "'MPOS_TEST_RUNNER FATAL: unittest assertions are no-ops: unittest "
     "was imported from a build with assert statements stripped "
-    "(mpy-cross -O3, e.g. the frozen lib of a prod firmware), so test "
-    "results would be vacuously green. Use a dev build, or ensure a "
-    "non-optimized lib/ is on sys.path before unittest is first "
-    "imported.')\n"
+    "(mpy-cross -O3, e.g. the frozen lib of a prod firmware), no working "
+    "lib/unittest was available to repair it, and test results would be "
+    "vacuously green. Use a dev build, or ensure a non-optimized "
+    "lib/unittest is on sys.path.')\n"
 )
 
 
@@ -389,6 +417,16 @@ class AIOREPLClient:
         r, _, _ = select.select([self.stream], [], [], timeout)
         return bool(r)
 
+    def _write_pasted(self, payload, chunk_size=256):
+        """Write a paste-mode payload in chunks, draining the echo between
+        chunks. aiorepl echoes every pasted byte back; writing a large
+        payload in one call can deadlock once the payload plus its echo
+        fill the PTY buffers, because nothing reads the echo until the
+        write completes."""
+        for i in range(0, len(payload), chunk_size):
+            self.stream.write(payload[i:i + chunk_size])
+            self._drain(0.02)
+
     def _drain(self, timeout=0.5):
         data = b""
         t0 = time.monotonic()
@@ -496,7 +534,7 @@ class AIOREPLClient:
         payload = ("print('{}')\n".format(SENTINEL)
                    + code.rstrip()
                    + "\nprint('{}')".format(END_MARKER))
-        self.stream.write(payload.encode("utf-8"))
+        self._write_pasted(payload.encode("utf-8"))
         self.stream.write(b"\x04")
 
         # aiorepl echoes all paste-mode input, so ``>>>`` in source
@@ -537,7 +575,7 @@ class AIOREPLClient:
         payload = ("print('{}')\n".format(SENTINEL)
                     + code.rstrip()
                     + "\nprint('{}')".format(END_MARKER))
-        self.stream.write(payload.encode("utf-8"))
+        self._write_pasted(payload.encode("utf-8"))
         self.stream.write(b"\x04")
 
         endings = (END_MARKER.encode() + b"\n", END_MARKER.encode() + b"\r\n")

--- a/scripts/mpos_controller.py
+++ b/scripts/mpos_controller.py
@@ -94,6 +94,33 @@ def _count_usb_serial_devices():
     )
 
 
+# Self-check pasted into every test run right after `import unittest`.
+# unittest's assert methods are plain `assert` statements, which
+# mpy-cross -O3 strips. When unittest resolves to such a build (e.g. the
+# frozen lib of a prod firmware, already imported at boot before lib/ is
+# prepended to sys.path), every assertion is a silent no-op and the whole
+# suite reports vacuously green. Abort loudly instead of "passing".
+_ASSERT_SELF_CHECK_CODE = (
+    "try:\n"
+    "    unittest.TestCase().assertTrue(False)\n"
+    "    _mpos_asserts_work = False\n"
+    "except AssertionError:\n"
+    "    _mpos_asserts_work = True\n"
+    "if not _mpos_asserts_work:\n"
+    "    print("
+    "'MPOS_TEST_RUNNER FATAL: unittest assertions are no-ops: unittest "
+    "was imported from a build with assert statements stripped "
+    "(mpy-cross -O3, e.g. the frozen lib of a prod firmware), so test "
+    "results would be vacuously green. Use a dev build, or ensure a "
+    "non-optimized lib/ is on sys.path before unittest is first "
+    "imported.')\n"
+)
+
+
+def _indent(code, prefix):
+    return "".join(prefix + line + "\n" for line in code.splitlines())
+
+
 def _build_test_code(test_path, tests_dir=None):
     with open(test_path) as f:
         test_content = f.read()
@@ -120,6 +147,7 @@ def _build_test_code(test_path, tests_dir=None):
     code += "except Exception:\n"
     code += "    pass\n"
     code += "import unittest\n"
+    code += _ASSERT_SELF_CHECK_CODE
     code += """\
 for _k in list(globals().keys()):
     _v = globals()[_k]
@@ -149,9 +177,12 @@ for _k in dir():
                 suite.addTest(_v)
         except Exception:
             pass
-result = unittest.TextTestRunner().run(suite)
 """
-    code += ("print('TEST WAS A SUCCESS' if result.wasSuccessful() "
+    code += "if not _mpos_asserts_work:\n"
+    code += "    print('TEST WAS A FAILURE')\n"
+    code += "else:\n"
+    code += "    result = unittest.TextTestRunner().run(suite)\n"
+    code += ("    print('TEST WAS A SUCCESS' if result.wasSuccessful() "
              "else 'TEST WAS A FAILURE')\n")
     return code
 
@@ -213,11 +244,15 @@ def _build_import_runner_code(tests_dir=None, coverage=False, coverage_paths=Non
         code += "mpos.coverage.start()\n"
         code += "_cov_stop = mpos.coverage.stop\n"
     code += "try:\n"
-    code += "    sys.modules.pop('_runner_test', None)\n"
-    code += "    import _runner_test as _test_mod\n"
     code += "    import unittest\n"
-    code += "    result = unittest.main(module=_test_mod)\n"
-    code += ("    print('TEST WAS A SUCCESS' if result.wasSuccessful() "
+    code += _indent(_ASSERT_SELF_CHECK_CODE, "    ")
+    code += "    if not _mpos_asserts_work:\n"
+    code += "        print('TEST WAS A FAILURE')\n"
+    code += "    else:\n"
+    code += "        sys.modules.pop('_runner_test', None)\n"
+    code += "        import _runner_test as _test_mod\n"
+    code += "        result = unittest.main(module=_test_mod)\n"
+    code += ("        print('TEST WAS A SUCCESS' if result.wasSuccessful() "
              "else 'TEST WAS A FAILURE')\n")
     if coverage:
         code += ("    _cov_rpt = {}\n"

--- a/tests/cpython_mpos_controller.py
+++ b/tests/cpython_mpos_controller.py
@@ -77,6 +77,7 @@ def run_tests(mpos, only=None, is_serial=False, cli_binary=None, serial_port=Non
         "helpers": test_controller_helpers,
         "readuntil": test_read_until,
         "mpremoteport": test_mpremote_port,
+        "assertguard": test_assert_guard,
     }
     if only:
         names = [s.strip() for s in only.split(",")]
@@ -196,6 +197,35 @@ def test_mpremote_port(mpos, is_serial=False, cli_binary=None, serial_port=None)
         )
     finally:
         builtins.__import__ = real_import
+
+
+def test_assert_guard(mpos, is_serial=False, cli_binary=None, serial_port=None):
+    section("unittest assertion self-check (run_test_file)")
+
+    # A failing assertion must never produce a passing run. On builds where
+    # unittest resolves to a lib compiled with mpy-cross -O3 (assert
+    # statements stripped, e.g. the frozen lib of a prod firmware), the
+    # runner's self-check must abort the run instead of reporting vacuous
+    # success; on dev builds the assertion itself fails the run.
+    os.makedirs("tmp", exist_ok=True)
+    failing_test = os.path.join("tmp", "_assert_guard_test.py")
+    with open(failing_test, "w") as f:
+        f.write(
+            "import unittest\n"
+            "\n"
+            "\n"
+            "class TestMustFail(unittest.TestCase):\n"
+            "    def test_failing_assert(self):\n"
+            "        self.assertTrue(False)\n"
+        )
+    try:
+        passed, out = mpos.run_test_file(failing_test)
+        check(
+            passed is False,
+            "run with a failing assertion is not reported as a success",
+        )
+    finally:
+        os.remove(failing_test)
 
 
 def test_basic(mpos, is_serial=False, cli_binary=None, serial_port=None):


### PR DESCRIPTION
## The problem

MicroPython's `unittest` implements every assert method with a bare `assert` statement, which `mpy-cross -O3` strips. On a desktop binary with the lib frozen at `-O3` (prod-style builds), boot imports `unittest` from the frozen lib before the test runner can prepend `lib/` to `sys.path`. From then on, **every assertion in every test is a silent no-op**: `assertTrue(False)` passes, and whole suites report vacuously green.

This was discovered while validating #276: its three new regression tests reported `ok` from `scripts/test_runner.py` on a frozen macOS binary both before and after the library fix, while a direct import-based run against the filesystem lib showed the true FAIL/PASS transition. Exceptions still surface (a `raise` inside a test shows as ERROR), which makes the false green especially convincing — the suite *looks* like it is executing and judging tests.

CI builds fresh dev binaries and is presumably unaffected; anyone running tests locally against a prod-style build gets meaningless results with no warning.

## The fix

Add a self-check right after `import unittest` in both generated harnesses (the import-based process runner and the paste-mode device runner in `scripts/mpos_controller.py`): verify `unittest.TestCase().assertTrue(False)` actually raises `AssertionError`. When it does not, print a clear diagnostic:

```
MPOS_TEST_RUNNER FATAL: unittest assertions are no-ops: unittest was imported from a build with assert statements stripped (mpy-cross -O3, e.g. the frozen lib of a prod firmware), so test results would be vacuously green. Use a dev build, or ensure a non-optimized lib/ is on sys.path before unittest is first imported.
```

and report `TEST WAS A FAILURE` instead of running the suite. (A `raise` was deliberately avoided — an uncaught exception in the pasted harness breaks the exec sentinel protocol and hangs the controller until timeout.)

## Tests

New `assertguard` section in `tests/cpython_mpos_controller.py`: a run of a test file containing one failing assertion must never be reported as a success. This is an invariant across build types:
- on a stripped build it passes via the new guard (verified on a frozen macOS binary: fails before this change with a vacuous green, passes after),
- on a dev build it passes because the assertion genuinely fails the run.

Existing `basic` and `helpers` sections still pass (26/26).

## Merge checklist

- CHANGELOG.md: entry added under Testing in "Future release".
- Tooling-only change; no manifests, docs pages, or boards affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
