### PR TITLE
WAVStream: honor repeat_count in desktop and web playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Frameworks:
 - DeepLink: new mpos.content.deeplink module with strict app-link parsing (exact host allowlist, identity-only links) and URL dispatch
 - FontManager: stop leaking an app's TTF and emoji fonts after the app closes by @fdb
 - FontManager: cache emoji codepoints for keyboard input by @fdb
+- AudioManager/WAVStream: desktop (afplay/ffplay/aplay/paplay and the no-player timing simulation) and web playback now honor set_repeat()/repeat_count like the ESP32 I2S path, so the MusicPlayer Repeat checkbox and other repeat users no longer silently play once on desktop builds; repeat_count is re-read each pass so set_repeat() changes apply mid-playback
 - Screenshot: move the BMP encoder out of the web server into mpos.ui.testing.encode_bmp(), which both now share, and add save_screenshot_bmp() to capture the screen straight into a file
 - TaskManager: add create_supervised_task(restart_on_return=True) and use it for the aiorepl console, so it is restarted when it exits
 - TaskManager: create_task returns None when the task manager is disabled, preventing C-level crashes from asyncio.create_task on ESP32 when called from a disabled test runner context

--- a/internal_filesystem/lib/mpos/audio/stream_wav.py
+++ b/internal_filesystem/lib/mpos/audio/stream_wav.py
@@ -484,71 +484,92 @@ class WAVStream:
 
         if player is None:
             logger.warning("Desktop audio: no player found (afplay/ffplay/aplay/paplay); simulating timing")
-            elapsed_ms = 0
-            while self._keep_running:
+
+        # Honor repeat_count like the I2S path does. repeat_count is re-read
+        # every pass so set_repeat() changes apply mid-playback.
+        self._repeat_played = 0
+        while self._keep_running:
+            if self._repeat_played >= self.repeat_count:
+                break
+            self._repeat_played += 1
+            self._progress_samples = 0
+
+            if player is None:
                 if self._duration_ms is None:
                     break
-                time.sleep_ms(100)
-                elapsed_ms += 100
-                if self._playback_rate:
-                    self._progress_samples = min(
-                        int(elapsed_ms / 1000.0 * self._playback_rate),
-                        self._total_samples
-                    )
-                if elapsed_ms >= self._duration_ms:
-                    break
-        else:
-            pid_file = "/tmp/mpos_audio_%d.pid" % id(self)
-            qpid = _shell_quote(pid_file)
-            if player == "afplay":
-                cmd = "afplay -v %.2f %s >/dev/null 2>&1 & echo $! > %s" % (
-                    max(0.0, min(1.0, self.volume / 100.0)),
-                    quoted,
-                    qpid
-                )
-            elif player == "ffplay":
-                cmd = "ffplay -nodisp -autoexit -loglevel quiet -volume %d %s >/dev/null 2>&1 & echo $! > %s" % (
-                    self.volume,
-                    quoted,
-                    qpid
-                )
-            elif player == "aplay":
-                cmd = "aplay -q %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
+                elapsed_ms = 0
+                while self._keep_running:
+                    time.sleep_ms(100)
+                    elapsed_ms += 100
+                    if self._playback_rate:
+                        self._progress_samples = min(
+                            int(elapsed_ms / 1000.0 * self._playback_rate),
+                            self._total_samples
+                        )
+                    if elapsed_ms >= self._duration_ms:
+                        break
             else:
-                cmd = "paplay %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
-
-            os.system(cmd)
-
-            start_ticks = time.ticks_ms()
-            while self._keep_running:
-                time.sleep_ms(100)
-                elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
-                if self._playback_rate:
-                    self._progress_samples = min(
-                        int(elapsed_ms / 1000.0 * self._playback_rate),
-                        self._total_samples
+                pid_file = "/tmp/mpos_audio_%d.pid" % id(self)
+                qpid = _shell_quote(pid_file)
+                if player == "afplay":
+                    cmd = "afplay -v %.2f %s >/dev/null 2>&1 & echo $! > %s" % (
+                        max(0.0, min(1.0, self.volume / 100.0)),
+                        quoted,
+                        qpid
                     )
-                if elapsed_ms >= (self._duration_ms or 0):
-                    break
+                elif player == "ffplay":
+                    cmd = "ffplay -nodisp -autoexit -loglevel quiet -volume %d %s >/dev/null 2>&1 & echo $! > %s" % (
+                        self.volume,
+                        quoted,
+                        qpid
+                    )
+                elif player == "aplay":
+                    cmd = "aplay -q %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
+                else:
+                    cmd = "paplay %s >/dev/null 2>&1 & echo $! > %s" % (quoted, qpid)
 
-            _stop_desktop_player(pid_file, not self._keep_running)
+                os.system(cmd)
+
+                start_ticks = time.ticks_ms()
+                while self._keep_running:
+                    time.sleep_ms(100)
+                    elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
+                    if self._playback_rate:
+                        self._progress_samples = min(
+                            int(elapsed_ms / 1000.0 * self._playback_rate),
+                            self._total_samples
+                        )
+                    if elapsed_ms >= (self._duration_ms or 0):
+                        break
+
+                _stop_desktop_player(pid_file, not self._keep_running)
 
         if self.on_complete:
             self.on_complete("Finished: %s" % self.file_path)
 
     async def _monitor_web_audio(self, webio):
-        start_ticks = time.ticks_ms()
         try:
+            # The first pass was already started by _play_desktop(). Honor
+            # repeat_count like the I2S path; it is re-read every pass so
+            # set_repeat() changes apply mid-playback.
+            self._repeat_played = 1
             while self._keep_running:
-                await asyncio.sleep_ms(100)
-                elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
-                if self._playback_rate:
-                    self._progress_samples = min(
-                        int(elapsed_ms / 1000.0 * self._playback_rate),
-                        self._total_samples
-                    )
-                if elapsed_ms >= (self._duration_ms or 0):
+                start_ticks = time.ticks_ms()
+                self._progress_samples = 0
+                while self._keep_running:
+                    await asyncio.sleep_ms(100)
+                    elapsed_ms = time.ticks_diff(time.ticks_ms(), start_ticks)
+                    if self._playback_rate:
+                        self._progress_samples = min(
+                            int(elapsed_ms / 1000.0 * self._playback_rate),
+                            self._total_samples
+                        )
+                    if elapsed_ms >= (self._duration_ms or 0):
+                        break
+                if not self._keep_running or self._repeat_played >= self.repeat_count:
                     break
+                self._repeat_played += 1
+                webio.audio_play(self.file_path, self.volume)
             if not self._keep_running:
                 webio.audio_stop()
             if self.on_complete:

--- a/tests/test_stream_wav.py
+++ b/tests/test_stream_wav.py
@@ -140,3 +140,103 @@ class TestComputePlaybackRate(unittest.TestCase):
         rate, factor = WAVStream.compute_playback_rate(44100, 8000)
         self.assertEqual(rate, 44100)
         self.assertEqual(factor, 1)
+
+
+class TestDesktopRepeat(unittest.TestCase):
+    """Desktop playback must honor repeat_count like the I2S path does.
+
+    Uses the no-player timing-simulation branch of _play_desktop() (headless)
+    by forcing _detect_desktop_player() to find nothing.
+    """
+
+    WAV_PATH = "tmp_test_stream_wav_repeat.wav"
+    SAMPLE_RATE = 8000
+    DURATION_MS = 300
+
+    def setUp(self):
+        import mpos.audio.stream_wav as stream_wav_module
+
+        self._module = stream_wav_module
+        self._orig_detect = stream_wav_module._detect_desktop_player
+        stream_wav_module._detect_desktop_player = lambda: None
+        self._write_wav()
+        self.completions = []
+
+    def tearDown(self):
+        self._module._detect_desktop_player = self._orig_detect
+        try:
+            import os
+            os.remove(self.WAV_PATH)
+        except OSError:
+            pass
+
+    def _write_wav(self):
+        # Minimal 16-bit PCM mono WAV of silence.
+        num_samples = self.SAMPLE_RATE * self.DURATION_MS // 1000
+        data_size = num_samples * 2
+        header = bytearray(44)
+        header[0:4] = b"RIFF"
+        header[4:8] = (36 + data_size).to_bytes(4, "little")
+        header[8:12] = b"WAVE"
+        header[12:16] = b"fmt "
+        header[16:20] = (16).to_bytes(4, "little")
+        header[20:22] = (1).to_bytes(2, "little")
+        header[22:24] = (1).to_bytes(2, "little")
+        header[24:28] = self.SAMPLE_RATE.to_bytes(4, "little")
+        header[28:32] = (self.SAMPLE_RATE * 2).to_bytes(4, "little")
+        header[32:34] = (2).to_bytes(2, "little")
+        header[34:36] = (16).to_bytes(2, "little")
+        header[36:40] = b"data"
+        header[40:44] = data_size.to_bytes(4, "little")
+        with open(self.WAV_PATH, "wb") as f:
+            f.write(header)
+            f.write(bytes(data_size))
+
+    def _make_stream(self):
+        return WAVStream(
+            self.WAV_PATH, 0, 70, {}, lambda m: self.completions.append(m)
+        )
+
+    def test_single_play_completes_once(self):
+        import time
+
+        stream = self._make_stream()
+        start = time.ticks_ms()
+        stream.play()
+        elapsed = time.ticks_diff(time.ticks_ms(), start)
+        self.assertEqual(stream._repeat_played, 1)
+        self.assertEqual(len(self.completions), 1)
+        self.assertTrue(elapsed < 2 * self.DURATION_MS,
+                        "single play took %s ms" % elapsed)
+
+    def test_repeat_plays_all_passes(self):
+        import time
+
+        stream = self._make_stream()
+        stream.set_repeat(3)
+        start = time.ticks_ms()
+        stream.play()
+        elapsed = time.ticks_diff(time.ticks_ms(), start)
+        self.assertEqual(stream._repeat_played, 3)
+        # on_complete fires once, after the final pass.
+        self.assertEqual(len(self.completions), 1)
+        self.assertTrue(elapsed >= int(2.5 * self.DURATION_MS),
+                        "3 passes took only %s ms" % elapsed)
+
+    def test_stop_breaks_endless_repeat(self):
+        import _thread
+        import time
+
+        stream = self._make_stream()
+        stream.set_repeat(1_000_000)
+        _thread.start_new_thread(stream.play, ())
+        time.sleep_ms(2 * self.DURATION_MS)
+        stream.stop()
+        for _ in range(50):
+            if not stream.is_playing():
+                break
+            time.sleep_ms(100)
+        self.assertFalse(stream.is_playing())
+        self.assertEqual(len(self.completions), 1)
+        # Far fewer passes than requested: stop() ended the loop.
+        self.assertTrue(stream._repeat_played < 100)


### PR DESCRIPTION
## The problem

`Player.set_repeat()` is a silent no-op everywhere except real hardware. The ESP32 `machine.I2S` path in `WAVStream` honors `repeat_count` (the while loop checking `_repeat_played >= repeat_count`), but:

- `_play_desktop()` — used on macOS/Linux via afplay/ffplay/aplay/paplay, and its no-player timing-simulation fallback — plays exactly one pass and completes;
- `_monitor_web_audio()` (web build) does the same.

Concretely: the MusicPlayer app's **Repeat checkbox does nothing on desktop builds**, and any app relying on repeat (e.g. an infinite-loop soundboard button) plays once. Discovered while testing ClipTV's infinite loop, which worked on-device semantics but died after one pass on desktop.

## The fix

Wrap both desktop branches in the same repeat loop the I2S path uses — bounded by `repeat_count`, `_repeat_played` and `_keep_running` — resetting `_progress_samples` per pass and calling `on_complete` only after the final pass. `repeat_count` is re-read every pass, so `set_repeat()` changes apply mid-playback (e.g. un-ticking MusicPlayer's Repeat lets the current pass finish and then stops), matching on-device behavior. The web monitor restarts `webio.audio_play()` for each additional pass.

## Tests

New `TestDesktopRepeat` in `tests/test_stream_wav.py`, driving the headless no-player simulation branch (forces `_detect_desktop_player()` to `None`, uses a generated 0.3 s silent WAV):

- a single play completes once (`_repeat_played == 1`, one `on_complete`, ~1 duration);
- `set_repeat(3)` plays three passes (~3 durations, still exactly one `on_complete`);
- `stop()` breaks an endless repeat promptly.

Before the fix the first two fail (repeat ignored, `_repeat_played` never advances). After it, all 20 stream_wav tests and all 30 audiomanager tests pass. Also verified live on macOS: a 3 s WAV with `set_repeat(1_000_000)` previously went silent after ~one pass and now plays continuously until stopped.

(Local runs used a direct import-based harness against `lib/` because of the stripped-frozen-unittest issue that #277 addresses.)

## Merge checklist

- CHANGELOG.md: entry added under Frameworks in "Future release".
- No manifests/docs/boards affected; no settings migration.
- Functional change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
