### PR TITLE
FileExplorer: list only path_pattern matches in pick mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Frameworks:
 - Camera: gracefully handle boards with no camera hardware (e.g. fri3d_2026) — show a 'No camera found' status instead of crashing on get_cameras()[0]
 - DNS (async_dns): single-flight lookups per name with a synchronous fallback when no worker thread can be spawned (e.g. boot-time thread pressure), so concurrent websocket/download connections no longer fail with 'can't create thread'
 - DeepLink: new mpos.content.deeplink module with strict app-link parsing (exact host allowlist, identity-only links) and URL dispatch
+- FileExplorer: pick mode with a path_pattern now lists only matching files (directories stay listed) — non-matching files could never be selected and taps on them were silently ignored, so listing them was pure clutter; browse mode still lists everything
 - FontManager: stop leaking an app's TTF and emoji fonts after the app closes by @fdb
 - FontManager: cache emoji codepoints for keyboard input by @fdb
 - Screenshot: move the BMP encoder out of the web server into mpos.ui.testing.encode_bmp(), which both now share, and add save_screenshot_bmp() to capture the screen straight into a file

--- a/internal_filesystem/lib/mpos/ui/file_explorer_activity.py
+++ b/internal_filesystem/lib/mpos/ui/file_explorer_activity.py
@@ -210,11 +210,25 @@ class FileExplorerActivity(Activity):
             self._path_to_btn[fullpath] = btn
 
         for f in files:
+            if not self._should_list_file(f):
+                continue
             fullpath = path + f
             btn = self._list.add_button(None, lv.SYMBOL.FILE + "  " + f)
             btn.add_event_cb(lambda e, p=fullpath: self._on_item_clicked(e, p, False), lv.EVENT.CLICKED, None)
             btn.add_event_cb(lambda e, p=fullpath: self._on_any_long_press(e, p), lv.EVENT.LONG_PRESSED, None)
             self._path_to_btn[fullpath] = btn
+
+    def _should_list_file(self, filename):
+        """In pick mode with a path_pattern, list only matching files.
+
+        Non-matching files could never be selected anyway (taps on them
+        were silently ignored), so listing them was pure clutter.
+        Directories are always listed: they stay navigable in browse mode
+        and selectable as a whole in pick mode.
+        """
+        if self._mode != self.MODE_PICK or not self._path_pattern:
+            return True
+        return self._path_matches(filename)
 
     def _on_item_clicked(self, e, path, is_dir):
         target = e.get_target_obj()

--- a/scripts/mpos_controller.py
+++ b/scripts/mpos_controller.py
@@ -94,6 +94,61 @@ def _count_usb_serial_devices():
     )
 
 
+# Self-check pasted into every test run right after `import unittest`.
+# unittest's assert methods are plain `assert` statements, which
+# mpy-cross -O3 strips. When unittest resolves to such a build (e.g. a
+# frozen copy already imported at boot, before lib/ is prepended to
+# sys.path), every assertion is a silent no-op and the whole suite
+# reports vacuously green.
+#
+# When that happens, try to self-heal: import the filesystem
+# lib/unittest (sys.path has lib/ first here) and graft its working
+# assert methods onto the cached module's TestCase, so classes that
+# already subclassed it (e.g. GraphicalTestCase) are repaired too.
+# Only when no working unittest is available does the run abort loudly
+# instead of "passing".
+_ASSERT_SELF_CHECK_CODE = (
+    "def _mpos_asserts_ok(_ut):\n"
+    "    try:\n"
+    "        _ut.TestCase().assertTrue(False)\n"
+    "        return False\n"
+    "    except AssertionError:\n"
+    "        return True\n"
+    "_mpos_asserts_work = _mpos_asserts_ok(unittest)\n"
+    "if not _mpos_asserts_work:\n"
+    "    _mpos_stripped_ut = sys.modules.pop('unittest', None)\n"
+    "    try:\n"
+    "        import unittest as _mpos_fresh_ut\n"
+    "    except ImportError:\n"
+    "        _mpos_fresh_ut = None\n"
+    "    if _mpos_stripped_ut is not None:\n"
+    "        sys.modules['unittest'] = _mpos_stripped_ut\n"
+    "    if (_mpos_fresh_ut is not None\n"
+    "            and _mpos_fresh_ut is not _mpos_stripped_ut\n"
+    "            and _mpos_asserts_ok(_mpos_fresh_ut)):\n"
+    "        for _mpos_name in dir(_mpos_fresh_ut.TestCase):\n"
+    "            if _mpos_name.startswith('assert'):\n"
+    "                setattr(_mpos_stripped_ut.TestCase, _mpos_name,\n"
+    "                        getattr(_mpos_fresh_ut.TestCase, _mpos_name))\n"
+    "        _mpos_asserts_work = _mpos_asserts_ok(unittest)\n"
+    "        if _mpos_asserts_work:\n"
+    "            print('MPOS_TEST_RUNNER: repaired stripped unittest assert "
+    "methods using lib/unittest')\n"
+    "if not _mpos_asserts_work:\n"
+    "    print("
+    "'MPOS_TEST_RUNNER FATAL: unittest assertions are no-ops: unittest "
+    "was imported from a build with assert statements stripped "
+    "(mpy-cross -O3, e.g. the frozen lib of a prod firmware), no working "
+    "lib/unittest was available to repair it, and test results would be "
+    "vacuously green. Use a dev build, or ensure a non-optimized "
+    "lib/unittest is on sys.path.')\n"
+)
+
+
+def _indent(code, prefix):
+    return "".join(prefix + line + "\n" for line in code.splitlines())
+
+
 def _build_test_code(test_path, tests_dir=None):
     with open(test_path) as f:
         test_content = f.read()
@@ -120,6 +175,7 @@ def _build_test_code(test_path, tests_dir=None):
     code += "except Exception:\n"
     code += "    pass\n"
     code += "import unittest\n"
+    code += _ASSERT_SELF_CHECK_CODE
     code += """\
 for _k in list(globals().keys()):
     _v = globals()[_k]
@@ -149,9 +205,12 @@ for _k in dir():
                 suite.addTest(_v)
         except Exception:
             pass
-result = unittest.TextTestRunner().run(suite)
 """
-    code += ("print('TEST WAS A SUCCESS' if result.wasSuccessful() "
+    code += "if not _mpos_asserts_work:\n"
+    code += "    print('TEST WAS A FAILURE')\n"
+    code += "else:\n"
+    code += "    result = unittest.TextTestRunner().run(suite)\n"
+    code += ("    print('TEST WAS A SUCCESS' if result.wasSuccessful() "
              "else 'TEST WAS A FAILURE')\n")
     return code
 
@@ -213,11 +272,15 @@ def _build_import_runner_code(tests_dir=None, coverage=False, coverage_paths=Non
         code += "mpos.coverage.start()\n"
         code += "_cov_stop = mpos.coverage.stop\n"
     code += "try:\n"
-    code += "    sys.modules.pop('_runner_test', None)\n"
-    code += "    import _runner_test as _test_mod\n"
     code += "    import unittest\n"
-    code += "    result = unittest.main(module=_test_mod)\n"
-    code += ("    print('TEST WAS A SUCCESS' if result.wasSuccessful() "
+    code += _indent(_ASSERT_SELF_CHECK_CODE, "    ")
+    code += "    if not _mpos_asserts_work:\n"
+    code += "        print('TEST WAS A FAILURE')\n"
+    code += "    else:\n"
+    code += "        sys.modules.pop('_runner_test', None)\n"
+    code += "        import _runner_test as _test_mod\n"
+    code += "        result = unittest.main(module=_test_mod)\n"
+    code += ("        print('TEST WAS A SUCCESS' if result.wasSuccessful() "
              "else 'TEST WAS A FAILURE')\n")
     if coverage:
         code += ("    _cov_rpt = {}\n"
@@ -354,6 +417,16 @@ class AIOREPLClient:
         r, _, _ = select.select([self.stream], [], [], timeout)
         return bool(r)
 
+    def _write_pasted(self, payload, chunk_size=256):
+        """Write a paste-mode payload in chunks, draining the echo between
+        chunks. aiorepl echoes every pasted byte back; writing a large
+        payload in one call can deadlock once the payload plus its echo
+        fill the PTY buffers, because nothing reads the echo until the
+        write completes."""
+        for i in range(0, len(payload), chunk_size):
+            self.stream.write(payload[i:i + chunk_size])
+            self._drain(0.02)
+
     def _drain(self, timeout=0.5):
         data = b""
         t0 = time.monotonic()
@@ -461,7 +534,7 @@ class AIOREPLClient:
         payload = ("print('{}')\n".format(SENTINEL)
                    + code.rstrip()
                    + "\nprint('{}')".format(END_MARKER))
-        self.stream.write(payload.encode("utf-8"))
+        self._write_pasted(payload.encode("utf-8"))
         self.stream.write(b"\x04")
 
         # aiorepl echoes all paste-mode input, so ``>>>`` in source
@@ -502,7 +575,7 @@ class AIOREPLClient:
         payload = ("print('{}')\n".format(SENTINEL)
                     + code.rstrip()
                     + "\nprint('{}')".format(END_MARKER))
-        self.stream.write(payload.encode("utf-8"))
+        self._write_pasted(payload.encode("utf-8"))
         self.stream.write(b"\x04")
 
         endings = (END_MARKER.encode() + b"\n", END_MARKER.encode() + b"\r\n")

--- a/tests/test_graphical_file_explorer_pick_filter.py
+++ b/tests/test_graphical_file_explorer_pick_filter.py
@@ -1,0 +1,110 @@
+"""
+Graphical test for FileExplorerActivity listing in pick mode.
+
+With a path_pattern, pick mode must list only matching files (non-matching
+files could never be selected — taps on them were silently ignored, so
+listing them was pure clutter). Directories are always listed: they stay
+navigable in browse mode and selectable as a whole in pick mode. Browse
+mode must keep listing everything.
+"""
+
+import os
+import unittest
+
+import mpos.ui
+from mpos import FileExplorerActivity, Intent, wait_for_render
+from mpos.activity_navigator import ActivityNavigator
+
+FIXTURE_DIR = "tmp_picker_filter_test"
+
+
+class TestGraphicalFileExplorerPickFilter(unittest.TestCase):
+
+    def setUp(self):
+        os.mkdir(FIXTURE_DIR)
+        os.mkdir(FIXTURE_DIR + "/sub")
+        for name in ("song.wav", "notes.md", "video.rgb565"):
+            with open(FIXTURE_DIR + "/" + name, "w") as f:
+                f.write("x")
+        self._to_launcher()
+
+    def tearDown(self):
+        self._to_launcher()
+        for name in ("song.wav", "notes.md", "video.rgb565"):
+            try:
+                os.remove(FIXTURE_DIR + "/" + name)
+            except OSError:
+                pass
+        for path in (FIXTURE_DIR + "/sub", FIXTURE_DIR):
+            try:
+                os.rmdir(path)
+            except OSError:
+                pass
+
+    def _to_launcher(self):
+        for _ in range(10):
+            if len(mpos.ui.screen_stack) <= 1:
+                break
+            mpos.ui.back_screen()
+            wait_for_render(5)
+
+    def _open_explorer(self, action=None, extras=None):
+        intent = Intent(
+            action=action,
+            activity_class=FileExplorerActivity,
+            extras=extras or {},
+        )
+        ActivityNavigator.startActivity(intent)
+        wait_for_render(10)
+        explorer = mpos.ui.screen_stack[-1][0]
+        self.assertEqual(type(explorer).__name__, "FileExplorerActivity")
+        return explorer
+
+    @staticmethod
+    def _listed_names(explorer):
+        return set(
+            path.rstrip("/").rsplit("/", 1)[-1]
+            for path in explorer._path_to_btn.keys()
+        )
+
+    def test_pick_mode_lists_only_matching_files_and_dirs(self):
+        explorer = self._open_explorer(
+            action="pick_file",
+            extras={
+                "start_dir": FIXTURE_DIR + "/",
+                "path_pattern": [".wav", ".rgb565"],
+            },
+        )
+        names = self._listed_names(explorer)
+        self.assertIn("song.wav", names)
+        self.assertIn("video.rgb565", names)
+        self.assertIn("sub", names)
+        self.assertFalse(
+            "notes.md" in names,
+            "non-matching file should not be listed in pick mode",
+        )
+
+    def test_pick_mode_without_pattern_lists_everything(self):
+        explorer = self._open_explorer(
+            action="pick_file",
+            extras={"start_dir": FIXTURE_DIR + "/"},
+        )
+        names = self._listed_names(explorer)
+        for expected in ("song.wav", "notes.md", "video.rgb565", "sub"):
+            self.assertIn(expected, names)
+
+    def test_browse_mode_lists_everything(self):
+        explorer = self._open_explorer(
+            extras={
+                "start_dir": FIXTURE_DIR + "/",
+                "mode": FileExplorerActivity.MODE_BROWSE,
+                "path_pattern": [".wav"],
+            },
+        )
+        names = self._listed_names(explorer)
+        for expected in ("song.wav", "notes.md", "video.rgb565", "sub"):
+            self.assertIn(expected, names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`pick_file` callers pass a `path_pattern` (MusicPlayer: `.wav`/`.rtttl`, ImageView: image extensions, third-party apps their own), but `FileExplorerActivity` only consulted the pattern at **selection** time (`_toggle_selection`). The listing showed every file in the directory, and tapping a non-matching one was **silently ignored** — no selection, no feedback. On a 320×240 screen that is clutter plus taps that look broken.

## The fix

Filter the file listing in pick mode when a `path_pattern` is given (new `_should_list_file()` used by `_populate_dir()`).

- **Directories are always listed** — they stay navigable in browse mode and selectable as a whole in pick mode (apps like the music player resolve a picked folder to the clips inside it).
- **Browse mode (the file manager) is unchanged** and still lists everything, pattern or not.
- Pick mode without a pattern also still lists everything.

## Tests

New `tests/test_graphical_file_explorer_pick_filter.py` builds a fixture directory (matching files, a non-matching file, a subdirectory) and covers all three cases via the live activity's listing:

- pick mode + pattern → only matching files plus the directory are listed (fails before the fix);
- pick mode without a pattern → everything listed;
- browse mode with a pattern present → everything listed.

All 3 pass after the fix, and the existing `test_graphical_start_activity_for_result.py` suite (which drives the picker through ImageView) still passes 4/4. Verified live as well: a soundboard app's `.wav`/`.rgb565` picker no longer shows `README.md` and friends.

(Local graphical runs used the self-healing harness from #277, since this machine's frozen build otherwise strips unittest asserts.)

## Merge checklist

- CHANGELOG.md: entry added under Frameworks in "Future release".
- No manifests/docs/boards affected; no settings migration.
- Functional change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
