### PR TITLE
Add board support: Waveshare ESP32-S3-Touch-LCD-3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Future release (next version)
 =====
 
 Board Support:
+- Add Waveshare ESP32-S3-Touch-LCD-3.5 (3.5" 320x480 ST7796 over SPI with LCD reset/CS on a PCA9554 IO expander, FT6336 touch, QMI8658 IMU, AXP2101 battery management); vendors the st7796 display driver and adds a PCA9554 expander driver
 - UNIHIKER K10: improve two-button navigation, correct camera preview orientation, and restore button input after camera operations
 - unix/macOS/web: compiler fallback to bytecode on architectures without a native emitter (e.g. macOS on Apple Silicon) instead of runtime-loaded apps using @micropython.native/@micropython.viper failing to import with SyntaxError 'invalid micropython decorator'
 

--- a/internal_filesystem/lib/drivers/display/st7796/__init__.py
+++ b/internal_filesystem/lib/drivers/display/st7796/__init__.py
@@ -1,0 +1,26 @@
+import sys
+from . import st7796
+from . import _st7796_init
+
+# Register _st7796_init in sys.modules so __import__('_st7796_init') can find it
+# This is needed because display_driver_framework.py uses __import__('_st7796_init')
+# expecting a top-level module, but _st7796_init is in the st7796 package subdirectory
+sys.modules['_st7796_init'] = _st7796_init
+
+# Explicitly define __all__ and re-export public symbols from st7796 module
+__all__ = [
+    'ST7796',
+    'STATE_HIGH',
+    'STATE_LOW',
+    'STATE_PWM',
+    'BYTE_ORDER_RGB',
+    'BYTE_ORDER_BGR',
+]
+
+# Re-export the public symbols
+ST7796 = st7796.ST7796
+STATE_HIGH = st7796.STATE_HIGH
+STATE_LOW = st7796.STATE_LOW
+STATE_PWM = st7796.STATE_PWM
+BYTE_ORDER_RGB = st7796.BYTE_ORDER_RGB
+BYTE_ORDER_BGR = st7796.BYTE_ORDER_BGR

--- a/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
+++ b/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2024 - 2025 Kevin G. Schlosser
+
+import time
+from micropython import const  # NOQA
+
+import lvgl as lv  # NOQA
+
+_SWRESET = const(0x01)
+_SLPOUT = const(0x11)
+_CSCON = const(0xF0)
+_MADCTL = const(0x36)
+_COLMOD = const(0x3A)
+_DIC = const(0xB4)
+_DFC = const(0xB6)
+_DOCA = const(0xE8)
+_PWR2 = const(0xC1)
+_PWR3 = const(0xC2)
+_VCMPCTL = const(0xC5)
+_PGC = const(0xE0)
+_NGC = const(0xE1)
+_DISPON = const(0x29)
+
+_EM = const(0xB7)
+
+
+def init(self):
+    param_buf = bytearray(14)
+    param_mv = memoryview(param_buf)
+
+    self.set_params(_SWRESET)
+
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_SLPOUT)
+
+    time.sleep_ms(120)  # NOQA
+
+    param_buf[0] = 0xC3
+    self.set_params(_CSCON, param_mv[:1])
+
+    param_buf[0] = 0x96
+    self.set_params(_CSCON, param_mv[:1])
+
+    param_buf[0] = (
+        self._madctl(
+            self._color_byte_order,
+            self._ORIENTATION_TABLE  # NOQA
+        )
+    )
+    self.set_params(_MADCTL, param_mv[:1])
+
+    color_size = lv.color_format_get_size(self._color_space)
+    if color_size == 2:  # NOQA
+        pixel_format = 0x05
+    elif color_size == 3:
+        pixel_format = 0x07
+    else:
+        raise RuntimeError(
+            'ST7796 IC only supports '
+            'lv.COLOR_FORMAT.RGB565 or lv.COLOR_FORMAT.RGB888'
+        )
+
+    param_buf[0] = pixel_format
+    self.set_params(_COLMOD, param_mv[:1])
+
+    param_buf[0] = 0xC6
+    self.set_params(_EM, param_mv[:1])
+
+    param_buf[0] = 0x01
+    self.set_params(_DIC, param_mv[:1])
+
+    param_buf[0] = 0x80
+    param_buf[1] = 0x02
+    param_buf[2] = 0x3B
+    self.set_params(_DFC, param_mv[:3])
+
+    param_buf[:8] = bytearray(
+        [
+            0x40, 0x8A, 0x00, 0x00, 0x29, 0x19, 0xA5, 0x33
+        ]
+    )
+    self._data_bus.tx_param(_DOCA, param_mv[:8])
+
+    param_buf[0] = 0x06
+    self.set_params(_PWR2, param_mv[:1])
+
+    param_buf[0] = 0xA7
+    self.set_params(_PWR3, param_mv[:1])
+
+    param_buf[0] = 0x18
+    self.set_params(_VCMPCTL, param_mv[:1])
+
+    time.sleep_ms(120)  # NOQA
+
+    param_buf[:14] = bytearray(
+        [
+            0xF0, 0x09, 0x0b, 0x06, 0x04, 0x15, 0x2F,
+            0x54, 0x42, 0x3C, 0x17, 0x14, 0x18, 0x1B
+        ]
+    )
+    self.set_params(_PGC, param_mv[:14])
+
+    param_buf[:14] = bytearray(
+        [
+            0xF0, 0x09, 0x0B, 0x06, 0x04, 0x03, 0x2D,
+            0x43, 0x42, 0x3B, 0x16, 0x14, 0x17, 0x1B
+        ]
+    )
+    self.set_params(_NGC, param_mv[:14])
+
+    time.sleep_ms(120)  # NOQA
+
+    param_buf[0] = 0x3C
+    self.set_params(_CSCON, param_mv[:1])
+
+    param_buf[0] = 0x69
+    self.set_params(_CSCON, param_mv[:1])
+
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_DISPON)
+
+    time.sleep_ms(120)  # NOQA

--- a/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
+++ b/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
@@ -18,6 +18,7 @@ _PWR3 = const(0xC2)
 _VCMPCTL = const(0xC5)
 _PGC = const(0xE0)
 _NGC = const(0xE1)
+_INVON = const(0x21)
 _DISPON = const(0x29)
 
 _EM = const(0xB7)
@@ -117,6 +118,11 @@ def init(self):
     self.set_params(_CSCON, param_mv[:1])
 
     time.sleep_ms(120)  # NOQA
+
+    # IPS panels are normally-inverted: without INVON the whole display
+    # renders in negative (verified on the Waveshare ESP32-S3-Touch-LCD-3.5).
+    # The st7789 driver does the same for the same reason.
+    self.set_params(_INVON)
 
     self.set_params(_DISPON)
 

--- a/internal_filesystem/lib/drivers/display/st7796/st7796.py
+++ b/internal_filesystem/lib/drivers/display/st7796/st7796.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 - 2025 Kevin G. Schlosser
+
+from micropython import const  # NOQA
+import display_driver_framework
+
+
+STATE_HIGH = display_driver_framework.STATE_HIGH
+STATE_LOW = display_driver_framework.STATE_LOW
+STATE_PWM = display_driver_framework.STATE_PWM
+
+BYTE_ORDER_RGB = display_driver_framework.BYTE_ORDER_RGB
+BYTE_ORDER_BGR = display_driver_framework.BYTE_ORDER_BGR
+
+_MADCTL_MV = const(0x20)
+_MADCTL_MX = const(0x40)
+_MADCTL_MY = const(0x80)
+
+
+class ST7796(display_driver_framework.DisplayDriver):
+
+    _ORIENTATION_TABLE = (
+        _MADCTL_MX,
+        _MADCTL_MV | _MADCTL_MY | _MADCTL_MX,
+        _MADCTL_MY,
+        _MADCTL_MV
+    )

--- a/internal_filesystem/lib/drivers/io_expander/pca9554.py
+++ b/internal_filesystem/lib/drivers/io_expander/pca9554.py
@@ -1,0 +1,44 @@
+import i2c
+from micropython import const
+
+
+class PCA9554:
+    """PCA9554 / TCA9554 8-bit I2C IO expansion chip.
+
+    Same register layout across the PCA9554/TCA9554/PCA9554A family:
+    input port, output port, polarity inversion, configuration.
+    Used e.g. on the Waveshare ESP32-S3-Touch-LCD-3.5, where the LCD
+    reset and chip-select lines are wired to expander pins EXIO1/EXIO2.
+    """
+
+    REG_INPUT = const(0x00)
+    REG_OUTPUT = const(0x01)
+    REG_POLARITY = const(0x02)
+    REG_CONFIG = const(0x03)
+
+    def __init__(self, i2c_bus: i2c.I2C.Bus, dev_id: int):
+        self.dev = i2c.I2C.Device(bus=i2c_bus, dev_id=dev_id, reg_bits=8)
+        self.directions = 0xFF     # all inputs by default (chip reset state)
+        self.output_states = 0x00
+
+    def _write_reg(self, reg, value):
+        self.dev.write_mem(reg, bytes([value & 0xFF]))
+
+    def _read_reg(self, reg):
+        buf = bytearray(1)
+        self.dev.read_mem(reg, buf=buf)
+        return buf[0]
+
+    def set_output(self, pin, value):
+        """Configure pin (0-7) as output and drive it high (True) or low."""
+        if value:
+            self.output_states |= (1 << pin)
+        else:
+            self.output_states &= ~(1 << pin)
+        self._write_reg(self.REG_OUTPUT, self.output_states)
+        self.directions &= ~(1 << pin)  # 0 = output
+        self._write_reg(self.REG_CONFIG, self.directions)
+
+    def get_input(self, pin):
+        """Read pin (0-7); pin must be configured as input (the default)."""
+        return bool(self._read_reg(self.REG_INPUT) & (1 << pin))

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -108,7 +108,10 @@ InputManager.register_indev(indev)
 
 # Landscape, like the other MPOS boards; must be done after initializing the
 # display and creating the touch driver so both agree on the orientation.
-mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._90)
+# _270 rather than _90 so the UI is upright with the board oriented USB
+# cable to the left / BOOT+RESET buttons at the bottom, the natural desk
+# position for this enclosure. Rotation only takes effect at init.
+mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._270)
 
 # === POWER MANAGEMENT (AXP2101) ===
 # Battery charge/percentage via the PMU instead of a raw ADC pin.

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -1,0 +1,140 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py initialization")
+# Hardware initialization for the Waveshare ESP32-S3-Touch-LCD-3.5:
+# 3.5" 320x480 IPS (ST7796 over SPI), FT6336 capacitive touch, QMI8658 IMU,
+# PCF85063 RTC, AXP2101 power management, ES8311 audio codec, TF card slot,
+# camera connector (OV5640/OV2640 supported but NOT included with the board).
+#
+# Manufacturer's wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5
+# Schematic: https://files.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5/ESP32-S3-Touch-LCD-3.5-Schematic.pdf
+#
+# Unlike the ESP32-S3-Touch-LCD-2, the LCD's reset and chip-select lines are
+# NOT on ESP32 GPIOs: they sit behind a PCA9554 I2C IO expander (EXIO1 = LCD
+# reset, EXIO2 = LCD chip select). Since the display is the only device on
+# the SPI bus, CS is simply driven low once at init and left there, and the
+# SPI bus is created without a CS pin.
+
+import time
+
+import drivers.display.st7796 as st7796
+import drivers.indev.ft6x36 as ft6x36
+import i2c
+import lcd_bus
+import lvgl as lv
+import machine
+import mpos.ui
+from drivers.io_expander.pca9554 import PCA9554
+from mpos import InputManager
+
+# Pin configuration (from the Waveshare demo code / schematic)
+SPI_BUS = 2
+SPI_FREQ = 40000000
+LCD_SCLK = 5
+LCD_MOSI = 1
+LCD_MISO = 2
+LCD_DC = 3
+LCD_BL = 6
+
+I2C_SDA = 8
+I2C_SCL = 7
+
+EXPANDER_ADDR = 0x20   # PCA9554
+EXIO_LCD_RESET = 1     # EXIO1
+EXIO_LCD_CS = 2        # EXIO2
+
+TOUCH_ADDR = 0x38      # FT6336
+PMU_ADDR = 0x34        # AXP2101
+IMU_ADDR = 0x6B        # QMI8658
+
+# Shared I2C bus: PCA9554 expander, FT6336 touch, AXP2101 PMU, QMI8658 IMU,
+# PCF85063 RTC (0x51), ES8311 codec.
+i2c_bus = i2c.I2C.Bus(host=0, scl=I2C_SCL, sda=I2C_SDA, freq=400000, use_locks=False)
+
+# Bring the LCD out of reset and assert its chip select via the expander,
+# BEFORE initializing the display controller over SPI.
+expander = PCA9554(i2c_bus, EXPANDER_ADDR)
+expander.set_output(EXIO_LCD_CS, False)    # CS low = selected (sole SPI device)
+expander.set_output(EXIO_LCD_RESET, False) # pulse reset
+time.sleep_ms(10)
+expander.set_output(EXIO_LCD_RESET, True)
+time.sleep_ms(120)                         # ST7796 needs ~120ms after reset
+
+if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py machine.SPI.Bus() initialization")
+try:
+    spi_bus = machine.SPI.Bus(host=SPI_BUS, mosi=LCD_MOSI, miso=LCD_MISO, sck=LCD_SCLK)
+except Exception as e:
+    logger.error("Error initializing SPI bus: %s" % (e))
+    if __debug__: logger.debug("Attempting hard reset in 3sec...")
+    time.sleep(3)
+    machine.reset()
+
+display_bus = lcd_bus.SPIBus(
+    spi_bus=spi_bus,
+    freq=SPI_FREQ,
+    dc=LCD_DC,
+    cs=-1,  # chip select is on the PCA9554 expander, held low above
+)
+
+# 320*480*2 = 307200 bytes full frame; use a DMA-capable strip like the
+# LCD-2 board does (320*45*2=28800 there). 320*48*2=30720 is a round strip
+# of 1/10th of this taller panel; tune once hardware timing is measured.
+_BUFFER_SIZE = const(320 * 48 * 2)  # 30720
+fb1 = display_bus.allocate_framebuffer(_BUFFER_SIZE, lcd_bus.MEMORY_INTERNAL | lcd_bus.MEMORY_DMA)
+fb2 = display_bus.allocate_framebuffer(_BUFFER_SIZE, lcd_bus.MEMORY_INTERNAL | lcd_bus.MEMORY_DMA)
+
+mpos.ui.main_display = st7796.ST7796(
+    data_bus=display_bus,
+    frame_buffer1=fb1,
+    frame_buffer2=fb2,
+    display_width=320,
+    display_height=480,
+    color_space=lv.COLOR_FORMAT.RGB565,
+    color_byte_order=st7796.BYTE_ORDER_BGR,
+    rgb565_byte_swap=True,
+    backlight_pin=LCD_BL,
+    backlight_on_state=st7796.STATE_PWM,
+)  # triggers lv.init()
+mpos.ui.main_display.init()
+mpos.ui.main_display.set_power(True)
+mpos.ui.main_display.set_backlight(100)
+
+# Touch handling:
+touch_dev = i2c.I2C.Device(bus=i2c_bus, dev_id=TOUCH_ADDR, reg_bits=8)
+indev = ft6x36.FT6x36(touch_dev)
+InputManager.register_indev(indev)
+
+# Landscape, like the other MPOS boards; must be done after initializing the
+# display and creating the touch driver so both agree on the orientation.
+mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._90)
+
+# === POWER MANAGEMENT (AXP2101) ===
+# Battery charge/percentage via the PMU instead of a raw ADC pin.
+# Same approach as lilygo_t_watch_s3_plus.
+try:
+    from drivers.power.AXP2101 import AXP2101
+
+    from mpos import BatteryManager
+    pmu = AXP2101(i2c_bus, addr=PMU_ADDR)
+    BatteryManager.read_raw_adc = lambda *args: 0
+    BatteryManager.has_battery = lambda *args: True
+    BatteryManager.get_battery_percentage = pmu.getBatteryPercent
+except Exception as e:
+    logger.error("AXP2101 init failed: %s" % (e))
+
+# === SENSOR HARDWARE ===
+# QMI8658 IMU on the shared I2C bus. Mounted position needs on-hardware
+# verification; FACING_EARTH matches the LCD-2 which uses the same IMU.
+from mpos import SensorManager
+
+SensorManager.init(i2c_bus, address=IMU_ADDR, mounted_position=SensorManager.FACING_EARTH)
+
+# === CAMERA ===
+# The board has a camera CONNECTOR (OV5640/OV2640 supported) but no camera is
+# included. Camera init is intentionally not set up here; if you attach one,
+# see waveshare_esp32_s3_touch_lcd_2.py for the CameraManager pattern (the
+# connector pinout is in the schematic linked above).
+
+if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py finished")

--- a/internal_filesystem/lib/mpos/main.py
+++ b/internal_filesystem/lib/mpos/main.py
@@ -245,6 +245,16 @@ def detect_board():
                     return "fri3d_2024"
                 restore_i2c(sda=9, scl=18)
 
+            if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5 ?")
+            if i2c0 := fail_save_i2c(sda=8, scl=7):
+                # PCA9554 IO expander (LCD reset/CS) + FT6336 touch: this pair on
+                # this bus is unique to the ESP32-S3-Touch-LCD-3.5 (the freenove
+                # board's FT6336G sits on sda=16/scl=15, the unihiker's expander
+                # on sda=47/scl=48).
+                if single_address_i2c_scan(i2c0, 0x20) and single_address_i2c_scan(i2c0, 0x38):
+                    return "waveshare_esp32_s3_touch_lcd_3_5"
+                restore_i2c(sda=8, scl=7)
+
         else: # not is_esp32s3
 
             if __debug__: logger.debug("m5stack_core2 ?")


### PR DESCRIPTION
Adds the 3.5" sibling of the supported ESP32-S3-Touch-LCD-2: [Waveshare ESP32-S3-Touch-LCD-3.5](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5) — 320×480 IPS (ST7796, SPI), FT6336 capacitive touch, QMI8658 IMU, PCF85063 RTC, AXP2101 PMU, ES8311 codec, TF slot, camera connector (OV5640/OV2640 supported, none included).

## What's in the change

- **`mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py`** — modeled closely on the LCD-2 board file. The key hardware difference: **LCD reset and chip-select are on a PCA9554 I2C IO expander** (EXIO1/EXIO2 @0x20), not GPIOs — the board file pulses reset and parks CS low via the expander before SPI display init (`cs=-1`; the panel is the only SPI device). Battery status comes from the AXP2101 (same pattern as lilygo_t_watch_s3_plus) instead of an ADC pin.
- **Vendored `drivers/display/st7796/`** from lvgl_micropython's api_drivers, with the same package glue as the existing st7789 (ft6x36 was already vendored).
- **New `drivers/io_expander/pca9554.py`** — minimal 8-bit sibling of the existing tca9555 driver.
- **Auto-detection** in `mpos/main.py`: PCA9554@0x20 **and** FT6336@0x38 on sda=8/scl=7 — a pair unique to this board among supported ones. Probed **last** in the S3 chain, with `restore_i2c` on miss, so existing boards see no behavior change.

## ✅ Verified on the physical board

Flashed to an actual ESP32-S3-Touch-LCD-3.5 and confirmed working **on first boot**:

- Display initializes via the expander reset/CS sequence: boot screen and launcher render correctly
- Orientation and colors correct (landscape, BGR + byte swap as configured)
- **Touch accurate** — taps land where the finger is, UI fully navigable
- Board auto-detected (it's the only path that brings up this panel)
- AXP2101 alive: `has_battery: True`, percentage `-1` (correct PMU answer for USB-only power, no LiPo attached)
- Build: `./scripts/build_mpos.sh esp32s3` passes, size check reports image 3,618,496 bytes / 51,520 headroom (~7.8 KB cost for the board support)

Still untested for lack of accessories rather than doubt: LiPo battery charging/percentage with an actual battery, TF card, camera on the connector, IMU mounted-orientation sign (initialized and detected, orientation needs a tilt test). The board file is commented at each of those points.

## Pin sources

GPIO map cross-checked between the Waveshare wiki/schematic ([PDF](https://files.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5/ESP32-S3-Touch-LCD-3.5-Schematic.pdf)) and two independent community configurations — and now validated by the hardware itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)