### PR TITLE
WAVStream: drain queued I2S audio by wall-clock instead of a fixed ibuf sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Frameworks:
 - AppManager: apps can declare URL handlers via 'urlPattern' in manifest intent_filters; patterns matching the official store host, mpos:// or micropythonos:// are reserved and rejected; multiple matching handlers open the chooser
 - AppManager: boot services can declare delay_s in their intent_filter; services with delay_s > 0 are imported and started asynchronously after the delay, keeping non-critical module imports out of the boot path
 - AppManager: manifest cache at /cache/system/apps.json with directory-count-based invalidation, skipping os.listdir/os.stat/json.load per app on subsequent boots when no apps were added or removed
+- AudioManager: WAVStream on ESP32 waits for the actual remaining queued audio after the last I2S write (wall-clock vs queued duration) instead of a fixed ibuf/bytes_per_second sleep, which delayed on_complete by up to 2 seconds for low-sample-rate clips (e.g. 8 kHz mono) and by ~0.4-0.7s for typical 22 kHz clips
 - Camera: after decoding a QR code in free-scan mode, show an 'Open in App Store' / 'Open link' chip when the code is an app link the OS can open
 - Camera: gracefully handle boards with no camera hardware (e.g. fri3d_2026) — show a 'No camera found' status instead of crashing on get_cameras()[0]
 - DNS (async_dns): single-flight lookups per name with a synchronous fallback when no worker thread can be spawned (e.g. boot-time thread pressure), so concurrent websocket/download connections no longer fail with 'can't create thread'

--- a/internal_filesystem/lib/mpos/audio/stream_wav.py
+++ b/internal_filesystem/lib/mpos/audio/stream_wav.py
@@ -295,6 +295,14 @@ class WAVStream:
         upsample_factor = (minimal_rate + original_rate - 1) // original_rate
         return original_rate * upsample_factor, upsample_factor
 
+    @staticmethod
+    def compute_drain_ms(played_ms, elapsed_ms):
+        """How much longer queued audio needs to finish playing, given the
+        duration of the audio queued so far and the wall-clock time spent
+        queueing it."""
+        drain_ms = int(played_ms) - int(elapsed_ms)
+        return drain_ms if drain_ms > 0 else 0
+
     # ----------------------------------------------------------------------
     #  Bit depth conversion functions
     # ----------------------------------------------------------------------
@@ -679,8 +687,9 @@ class WAVStream:
 
                 if __debug__: logger.debug("Playing %s bytes (volume %s%%)", data_size, self.volume)
 
-                bytes_per_second_out = playback_rate * 2 * channels
                 self._repeat_played = 0
+                play_start_ms = time.ticks_ms()
+                played_ms = 0
 
                 # Chunk decode moved to _read_decode_chunk method.
 
@@ -733,13 +742,18 @@ class WAVStream:
                         if self._keep_running:
                             time.sleep_ms(1)
 
+                    if original_rate > 0:
+                        played_ms += self._progress_samples * 1000 // original_rate
+
                 if self._i2s and self._keep_running:
-                    try:
-                        drain_ms = int((ibuf / bytes_per_second_out) * 1000)
-                        if drain_ms > 0:
-                            time.sleep_ms(drain_ms)
-                    except Exception as e:
-                        logger.error("Drain wait failed: %s", e)
+                    # Wait for queued audio to finish playing: sleep until the
+                    # wall clock catches up with the duration that was queued.
+                    # A fixed ibuf/bytes_per_second estimate overshoots badly
+                    # at low byte rates (2 extra seconds at 8 kHz mono).
+                    elapsed_ms = time.ticks_diff(time.ticks_ms(), play_start_ms)
+                    drain_ms = WAVStream.compute_drain_ms(played_ms, elapsed_ms)
+                    if drain_ms > 0:
+                        time.sleep_ms(drain_ms)
 
                 if __debug__: logger.debug("Finished playing %s", self.file_path)
                 if self.on_complete:

--- a/tests/test_stream_wav.py
+++ b/tests/test_stream_wav.py
@@ -140,3 +140,16 @@ class TestComputePlaybackRate(unittest.TestCase):
         rate, factor = WAVStream.compute_playback_rate(44100, 8000)
         self.assertEqual(rate, 44100)
         self.assertEqual(factor, 1)
+
+
+class TestComputeDrainMs(unittest.TestCase):
+
+    def test_wall_clock_behind_audio_waits_for_the_difference(self):
+        self.assertEqual(WAVStream.compute_drain_ms(3000, 2900), 100)
+
+    def test_wall_clock_caught_up_means_no_wait(self):
+        self.assertEqual(WAVStream.compute_drain_ms(3000, 3000), 0)
+
+    def test_wall_clock_ahead_of_audio_means_no_wait(self):
+        # e.g. playback stalled and ran long: never sleep a negative amount
+        self.assertEqual(WAVStream.compute_drain_ms(2000, 4171), 0)


### PR DESCRIPTION
## Problem

On ESP32, `WAVStream.play()` sleeps a fixed `ibuf / bytes_per_second` after the last I2S write before firing `on_complete`. But the blocking write loop already paces against DMA drain (measured: writes complete in almost exactly the clip duration), so nearly nothing is left queued when the loop exits — and the fixed estimate overshoots by the full ibuf duration, worst at low byte rates:

| clip | overshoot | end-to-end before | after |
|---|---|---|---|
| 2 s 8 kHz mono | +2048 ms | 4185 ms | 2219 ms |
| 3 s 22.05 kHz mono | +743 ms | 3870 ms | 3215 ms |
| 3 s 22.05 kHz stereo | +371 ms | 3486 ms | 3202 ms |

(Measured on a Waveshare ESP32-S3-Touch-LCD-3.5 through an ES8311 "Speaker" output, player start → `on_complete`; the residual ~200 ms is player-thread startup + codec `on_open`, not drain error.)

Every clip appears to run long, and anything sequencing off `on_complete` (playlists, repeat chaining, sound-then-action flows) inherits the same dead gap between clips.

## Fix

Track the duration of the audio actually queued (`_progress_samples` over the original rate — correct for ADPCM and for upsampled playback, since upsampling scales data and rate by the same factor) and the wall-clock time spent queueing it, then sleep only the difference: `compute_drain_ms(played_ms, elapsed_ms)`. If playback ran long (stalls), the drain is clamped to zero rather than sleeping a negative/absurd amount.

This also self-adapts if the underlying `machine.I2S` buffering behavior ever changes: the drain is derived from observed pacing, not from a driver-internal constant.

## Verification

- Raw `machine.I2S` consumption rates were measured first on hardware to rule out clock/slot-config bugs: mono and stereo at 22050 Hz and mono at 8000 Hz all drain within ~1% of nominal, deterministically. The wall-clock discrepancies were entirely the drain sleep.
- Fix verified end-to-end on the ESP32-S3 device by loading the patched module (numbers above), including a repeat run through the real `AudioManager` → output `on_open`/`on_close` path.
- New unit tests for `compute_drain_ms`; full `tests/test_stream_wav.py` and `tests/test_audiomanager.py` pass on the desktop build.
- `ruff` clean.

## Merge checklist

- [ ] `tests/test_stream_wav.py` passes
- [ ] `tests/test_audiomanager.py` passes
- [ ] CHANGELOG entry under "Future release"
- [ ] Verified on ESP32 hardware (Waveshare ESP32-S3-Touch-LCD-3.5, ES8311)

🤖 Generated with [Claude Code](https://claude.com/claude-code)