### PR TITLE
Waveshare ESP32-S3-Touch-LCD-3.5: camera connector support (OV5640/OV2640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Future release (next version)
 =====
 
 Board Support:
+- Add Waveshare ESP32-S3-Touch-LCD-3.5 (3.5" 320x480 ST7796 over SPI with LCD reset/CS on a PCA9554 IO expander, FT6336 touch, QMI8658 IMU, AXP2101 battery management); vendors the st7796 display driver and adds a PCA9554 expander driver
 - UNIHIKER K10: improve two-button navigation, correct camera preview orientation, and restore button input after camera operations
 - unix/macOS/web: compiler fallback to bytecode on architectures without a native emitter (e.g. macOS on Apple Silicon) instead of runtime-loaded apps using @micropython.native/@micropython.viper failing to import with SyntaxError 'invalid micropython decorator'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Future release (next version)
 =====
 
 Board Support:
+- Waveshare ESP32-S3-Touch-LCD-3.5: ES8311 audio support (speaker output + microphone input over I2S, DAC volume default tuned by ear on hardware)
 - Add Waveshare ESP32-S3-Touch-LCD-3.5 (3.5" 320x480 ST7796 over SPI with LCD reset/CS on a PCA9554 IO expander, FT6336 touch, QMI8658 IMU, AXP2101 battery management); vendors the st7796 display driver and adds a PCA9554 expander driver
 - UNIHIKER K10: improve two-button navigation, correct camera preview orientation, and restore button input after camera operations
 - unix/macOS/web: compiler fallback to bytecode on architectures without a native emitter (e.g. macOS on Apple Silicon) instead of runtime-loaded apps using @micropython.native/@micropython.viper failing to import with SyntaxError 'invalid micropython decorator'

--- a/internal_filesystem/lib/drivers/display/st7796/__init__.py
+++ b/internal_filesystem/lib/drivers/display/st7796/__init__.py
@@ -1,0 +1,26 @@
+import sys
+from . import st7796
+from . import _st7796_init
+
+# Register _st7796_init in sys.modules so __import__('_st7796_init') can find it
+# This is needed because display_driver_framework.py uses __import__('_st7796_init')
+# expecting a top-level module, but _st7796_init is in the st7796 package subdirectory
+sys.modules['_st7796_init'] = _st7796_init
+
+# Explicitly define __all__ and re-export public symbols from st7796 module
+__all__ = [
+    'ST7796',
+    'STATE_HIGH',
+    'STATE_LOW',
+    'STATE_PWM',
+    'BYTE_ORDER_RGB',
+    'BYTE_ORDER_BGR',
+]
+
+# Re-export the public symbols
+ST7796 = st7796.ST7796
+STATE_HIGH = st7796.STATE_HIGH
+STATE_LOW = st7796.STATE_LOW
+STATE_PWM = st7796.STATE_PWM
+BYTE_ORDER_RGB = st7796.BYTE_ORDER_RGB
+BYTE_ORDER_BGR = st7796.BYTE_ORDER_BGR

--- a/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
+++ b/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2024 - 2025 Kevin G. Schlosser
+
+import time
+from micropython import const  # NOQA
+
+import lvgl as lv  # NOQA
+
+_SWRESET = const(0x01)
+_SLPOUT = const(0x11)
+_CSCON = const(0xF0)
+_MADCTL = const(0x36)
+_COLMOD = const(0x3A)
+_DIC = const(0xB4)
+_DFC = const(0xB6)
+_DOCA = const(0xE8)
+_PWR2 = const(0xC1)
+_PWR3 = const(0xC2)
+_VCMPCTL = const(0xC5)
+_PGC = const(0xE0)
+_NGC = const(0xE1)
+_DISPON = const(0x29)
+
+_EM = const(0xB7)
+
+
+def init(self):
+    param_buf = bytearray(14)
+    param_mv = memoryview(param_buf)
+
+    self.set_params(_SWRESET)
+
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_SLPOUT)
+
+    time.sleep_ms(120)  # NOQA
+
+    param_buf[0] = 0xC3
+    self.set_params(_CSCON, param_mv[:1])
+
+    param_buf[0] = 0x96
+    self.set_params(_CSCON, param_mv[:1])
+
+    param_buf[0] = (
+        self._madctl(
+            self._color_byte_order,
+            self._ORIENTATION_TABLE  # NOQA
+        )
+    )
+    self.set_params(_MADCTL, param_mv[:1])
+
+    color_size = lv.color_format_get_size(self._color_space)
+    if color_size == 2:  # NOQA
+        pixel_format = 0x05
+    elif color_size == 3:
+        pixel_format = 0x07
+    else:
+        raise RuntimeError(
+            'ST7796 IC only supports '
+            'lv.COLOR_FORMAT.RGB565 or lv.COLOR_FORMAT.RGB888'
+        )
+
+    param_buf[0] = pixel_format
+    self.set_params(_COLMOD, param_mv[:1])
+
+    param_buf[0] = 0xC6
+    self.set_params(_EM, param_mv[:1])
+
+    param_buf[0] = 0x01
+    self.set_params(_DIC, param_mv[:1])
+
+    param_buf[0] = 0x80
+    param_buf[1] = 0x02
+    param_buf[2] = 0x3B
+    self.set_params(_DFC, param_mv[:3])
+
+    param_buf[:8] = bytearray(
+        [
+            0x40, 0x8A, 0x00, 0x00, 0x29, 0x19, 0xA5, 0x33
+        ]
+    )
+    self._data_bus.tx_param(_DOCA, param_mv[:8])
+
+    param_buf[0] = 0x06
+    self.set_params(_PWR2, param_mv[:1])
+
+    param_buf[0] = 0xA7
+    self.set_params(_PWR3, param_mv[:1])
+
+    param_buf[0] = 0x18
+    self.set_params(_VCMPCTL, param_mv[:1])
+
+    time.sleep_ms(120)  # NOQA
+
+    param_buf[:14] = bytearray(
+        [
+            0xF0, 0x09, 0x0b, 0x06, 0x04, 0x15, 0x2F,
+            0x54, 0x42, 0x3C, 0x17, 0x14, 0x18, 0x1B
+        ]
+    )
+    self.set_params(_PGC, param_mv[:14])
+
+    param_buf[:14] = bytearray(
+        [
+            0xF0, 0x09, 0x0B, 0x06, 0x04, 0x03, 0x2D,
+            0x43, 0x42, 0x3B, 0x16, 0x14, 0x17, 0x1B
+        ]
+    )
+    self.set_params(_NGC, param_mv[:14])
+
+    time.sleep_ms(120)  # NOQA
+
+    param_buf[0] = 0x3C
+    self.set_params(_CSCON, param_mv[:1])
+
+    param_buf[0] = 0x69
+    self.set_params(_CSCON, param_mv[:1])
+
+    time.sleep_ms(120)  # NOQA
+
+    self.set_params(_DISPON)
+
+    time.sleep_ms(120)  # NOQA

--- a/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
+++ b/internal_filesystem/lib/drivers/display/st7796/_st7796_init.py
@@ -18,6 +18,7 @@ _PWR3 = const(0xC2)
 _VCMPCTL = const(0xC5)
 _PGC = const(0xE0)
 _NGC = const(0xE1)
+_INVON = const(0x21)
 _DISPON = const(0x29)
 
 _EM = const(0xB7)
@@ -117,6 +118,11 @@ def init(self):
     self.set_params(_CSCON, param_mv[:1])
 
     time.sleep_ms(120)  # NOQA
+
+    # IPS panels are normally-inverted: without INVON the whole display
+    # renders in negative (verified on the Waveshare ESP32-S3-Touch-LCD-3.5).
+    # The st7789 driver does the same for the same reason.
+    self.set_params(_INVON)
 
     self.set_params(_DISPON)
 

--- a/internal_filesystem/lib/drivers/display/st7796/st7796.py
+++ b/internal_filesystem/lib/drivers/display/st7796/st7796.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 - 2025 Kevin G. Schlosser
+
+from micropython import const  # NOQA
+import display_driver_framework
+
+
+STATE_HIGH = display_driver_framework.STATE_HIGH
+STATE_LOW = display_driver_framework.STATE_LOW
+STATE_PWM = display_driver_framework.STATE_PWM
+
+BYTE_ORDER_RGB = display_driver_framework.BYTE_ORDER_RGB
+BYTE_ORDER_BGR = display_driver_framework.BYTE_ORDER_BGR
+
+_MADCTL_MV = const(0x20)
+_MADCTL_MX = const(0x40)
+_MADCTL_MY = const(0x80)
+
+
+class ST7796(display_driver_framework.DisplayDriver):
+
+    _ORIENTATION_TABLE = (
+        _MADCTL_MX,
+        _MADCTL_MV | _MADCTL_MY | _MADCTL_MX,
+        _MADCTL_MY,
+        _MADCTL_MV
+    )

--- a/internal_filesystem/lib/drivers/io_expander/pca9554.py
+++ b/internal_filesystem/lib/drivers/io_expander/pca9554.py
@@ -1,0 +1,44 @@
+import i2c
+from micropython import const
+
+
+class PCA9554:
+    """PCA9554 / TCA9554 8-bit I2C IO expansion chip.
+
+    Same register layout across the PCA9554/TCA9554/PCA9554A family:
+    input port, output port, polarity inversion, configuration.
+    Used e.g. on the Waveshare ESP32-S3-Touch-LCD-3.5, where the LCD
+    reset and chip-select lines are wired to expander pins EXIO1/EXIO2.
+    """
+
+    REG_INPUT = const(0x00)
+    REG_OUTPUT = const(0x01)
+    REG_POLARITY = const(0x02)
+    REG_CONFIG = const(0x03)
+
+    def __init__(self, i2c_bus: i2c.I2C.Bus, dev_id: int):
+        self.dev = i2c.I2C.Device(bus=i2c_bus, dev_id=dev_id, reg_bits=8)
+        self.directions = 0xFF     # all inputs by default (chip reset state)
+        self.output_states = 0x00
+
+    def _write_reg(self, reg, value):
+        self.dev.write_mem(reg, bytes([value & 0xFF]))
+
+    def _read_reg(self, reg):
+        buf = bytearray(1)
+        self.dev.read_mem(reg, buf=buf)
+        return buf[0]
+
+    def set_output(self, pin, value):
+        """Configure pin (0-7) as output and drive it high (True) or low."""
+        if value:
+            self.output_states |= (1 << pin)
+        else:
+            self.output_states &= ~(1 << pin)
+        self._write_reg(self.REG_OUTPUT, self.output_states)
+        self.directions &= ~(1 << pin)  # 0 = output
+        self._write_reg(self.REG_CONFIG, self.directions)
+
+    def get_input(self, pin):
+        """Read pin (0-7); pin must be configured as input (the default)."""
+        return bool(self._read_reg(self.REG_INPUT) & (1 << pin))

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -108,7 +108,10 @@ InputManager.register_indev(indev)
 
 # Landscape, like the other MPOS boards; must be done after initializing the
 # display and creating the touch driver so both agree on the orientation.
-mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._90)
+# _270 rather than _90 so the UI is upright with the board oriented USB
+# cable to the left / BOOT+RESET buttons at the bottom, the natural desk
+# position for this enclosure. Rotation only takes effect at init.
+mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._270)
 
 # === POWER MANAGEMENT (AXP2101) ===
 # Battery charge/percentage via the PMU instead of a raw ADC pin.

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -1,0 +1,140 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py initialization")
+# Hardware initialization for the Waveshare ESP32-S3-Touch-LCD-3.5:
+# 3.5" 320x480 IPS (ST7796 over SPI), FT6336 capacitive touch, QMI8658 IMU,
+# PCF85063 RTC, AXP2101 power management, ES8311 audio codec, TF card slot,
+# camera connector (OV5640/OV2640 supported but NOT included with the board).
+#
+# Manufacturer's wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5
+# Schematic: https://files.waveshare.com/wiki/ESP32-S3-Touch-LCD-3.5/ESP32-S3-Touch-LCD-3.5-Schematic.pdf
+#
+# Unlike the ESP32-S3-Touch-LCD-2, the LCD's reset and chip-select lines are
+# NOT on ESP32 GPIOs: they sit behind a PCA9554 I2C IO expander (EXIO1 = LCD
+# reset, EXIO2 = LCD chip select). Since the display is the only device on
+# the SPI bus, CS is simply driven low once at init and left there, and the
+# SPI bus is created without a CS pin.
+
+import time
+
+import drivers.display.st7796 as st7796
+import drivers.indev.ft6x36 as ft6x36
+import i2c
+import lcd_bus
+import lvgl as lv
+import machine
+import mpos.ui
+from drivers.io_expander.pca9554 import PCA9554
+from mpos import InputManager
+
+# Pin configuration (from the Waveshare demo code / schematic)
+SPI_BUS = 2
+SPI_FREQ = 40000000
+LCD_SCLK = 5
+LCD_MOSI = 1
+LCD_MISO = 2
+LCD_DC = 3
+LCD_BL = 6
+
+I2C_SDA = 8
+I2C_SCL = 7
+
+EXPANDER_ADDR = 0x20   # PCA9554
+EXIO_LCD_RESET = 1     # EXIO1
+EXIO_LCD_CS = 2        # EXIO2
+
+TOUCH_ADDR = 0x38      # FT6336
+PMU_ADDR = 0x34        # AXP2101
+IMU_ADDR = 0x6B        # QMI8658
+
+# Shared I2C bus: PCA9554 expander, FT6336 touch, AXP2101 PMU, QMI8658 IMU,
+# PCF85063 RTC (0x51), ES8311 codec.
+i2c_bus = i2c.I2C.Bus(host=0, scl=I2C_SCL, sda=I2C_SDA, freq=400000, use_locks=False)
+
+# Bring the LCD out of reset and assert its chip select via the expander,
+# BEFORE initializing the display controller over SPI.
+expander = PCA9554(i2c_bus, EXPANDER_ADDR)
+expander.set_output(EXIO_LCD_CS, False)    # CS low = selected (sole SPI device)
+expander.set_output(EXIO_LCD_RESET, False) # pulse reset
+time.sleep_ms(10)
+expander.set_output(EXIO_LCD_RESET, True)
+time.sleep_ms(120)                         # ST7796 needs ~120ms after reset
+
+if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py machine.SPI.Bus() initialization")
+try:
+    spi_bus = machine.SPI.Bus(host=SPI_BUS, mosi=LCD_MOSI, miso=LCD_MISO, sck=LCD_SCLK)
+except Exception as e:
+    logger.error("Error initializing SPI bus: %s" % (e))
+    if __debug__: logger.debug("Attempting hard reset in 3sec...")
+    time.sleep(3)
+    machine.reset()
+
+display_bus = lcd_bus.SPIBus(
+    spi_bus=spi_bus,
+    freq=SPI_FREQ,
+    dc=LCD_DC,
+    cs=-1,  # chip select is on the PCA9554 expander, held low above
+)
+
+# 320*480*2 = 307200 bytes full frame; use a DMA-capable strip like the
+# LCD-2 board does (320*45*2=28800 there). 320*48*2=30720 is a round strip
+# of 1/10th of this taller panel; tune once hardware timing is measured.
+_BUFFER_SIZE = const(320 * 48 * 2)  # 30720
+fb1 = display_bus.allocate_framebuffer(_BUFFER_SIZE, lcd_bus.MEMORY_INTERNAL | lcd_bus.MEMORY_DMA)
+fb2 = display_bus.allocate_framebuffer(_BUFFER_SIZE, lcd_bus.MEMORY_INTERNAL | lcd_bus.MEMORY_DMA)
+
+mpos.ui.main_display = st7796.ST7796(
+    data_bus=display_bus,
+    frame_buffer1=fb1,
+    frame_buffer2=fb2,
+    display_width=320,
+    display_height=480,
+    color_space=lv.COLOR_FORMAT.RGB565,
+    color_byte_order=st7796.BYTE_ORDER_BGR,
+    rgb565_byte_swap=True,
+    backlight_pin=LCD_BL,
+    backlight_on_state=st7796.STATE_PWM,
+)  # triggers lv.init()
+mpos.ui.main_display.init()
+mpos.ui.main_display.set_power(True)
+mpos.ui.main_display.set_backlight(100)
+
+# Touch handling:
+touch_dev = i2c.I2C.Device(bus=i2c_bus, dev_id=TOUCH_ADDR, reg_bits=8)
+indev = ft6x36.FT6x36(touch_dev)
+InputManager.register_indev(indev)
+
+# Landscape, like the other MPOS boards; must be done after initializing the
+# display and creating the touch driver so both agree on the orientation.
+mpos.ui.main_display.set_rotation(lv.DISPLAY_ROTATION._90)
+
+# === POWER MANAGEMENT (AXP2101) ===
+# Battery charge/percentage via the PMU instead of a raw ADC pin.
+# Same approach as lilygo_t_watch_s3_plus.
+try:
+    from drivers.power.AXP2101 import AXP2101
+
+    from mpos import BatteryManager
+    pmu = AXP2101(i2c_bus, addr=PMU_ADDR)
+    BatteryManager.read_raw_adc = lambda *args: 0
+    BatteryManager.has_battery = lambda *args: True
+    BatteryManager.get_battery_percentage = pmu.getBatteryPercent
+except Exception as e:
+    logger.error("AXP2101 init failed: %s" % (e))
+
+# === SENSOR HARDWARE ===
+# QMI8658 IMU on the shared I2C bus. Mounted position needs on-hardware
+# verification; FACING_EARTH matches the LCD-2 which uses the same IMU.
+from mpos import SensorManager
+
+SensorManager.init(i2c_bus, address=IMU_ADDR, mounted_position=SensorManager.FACING_EARTH)
+
+# === CAMERA ===
+# The board has a camera CONNECTOR (OV5640/OV2640 supported) but no camera is
+# included. Camera init is intentionally not set up here; if you attach one,
+# see waveshare_esp32_s3_touch_lcd_2.py for the CameraManager pattern (the
+# connector pinout is in the schematic linked above).
+
+if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py finished")

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -131,6 +131,88 @@ from mpos import SensorManager
 
 SensorManager.init(i2c_bus, address=IMU_ADDR, mounted_position=SensorManager.FACING_EARTH)
 
+# === AUDIO (ES8311 codec, onboard speaker connector + microphone) ===
+# I2S pins from Waveshare's demo code (01_audio_out / 04_es8311_example):
+# MCLK=12, BCLK=13, LRCK/WS=15, ESP32->codec (playback)=16, codec->ESP32
+# (microphone)=14. Codec control is I2C @0x18 on the shared bus. The
+# board has no separate speaker-amp enable pin in Waveshare's examples,
+# so only the codec's DAC soft-mute is used for pop suppression.
+_es8311 = None
+try:
+    import time as _time
+
+    import drivers.codec.es8311 as es8311_drv
+
+    class _CodecI2C:
+        """Adapt the lcd_bus i2c wrapper to the machine.I2C-style API the
+        ES8311 driver expects (writeto_mem/readfrom_mem_into)."""
+
+        def __init__(self, bus, dev_id):
+            self._dev = i2c.I2C.Device(bus=bus, dev_id=dev_id, reg_bits=8)
+
+        def writeto_mem(self, addr, reg, data):
+            self._dev.write_mem(reg, data)
+
+        def readfrom_mem_into(self, addr, reg, buf):
+            self._dev.read_mem(reg, buf=buf)
+
+    _es8311 = es8311_drv.ES8311(_CodecI2C(i2c_bus, 0x18))
+    # 76% was picked by ear on real hardware: the driver's 85% default is
+    # audibly distorted through the speaker connector, 70% is clean but
+    # quiet, 76% is the loudest clean setting.
+    _es8311.set_dac_volume(76)
+except Exception as e:
+    logger.error("ES8311 init failed: %s" % (e))
+
+
+def _audio_on_open():
+    """Called after MCLK starts and before I2S init: release DAC soft-mute."""
+    if _es8311:
+        _time.sleep_ms(10)
+        _es8311.dac_mute(False)
+
+
+def _audio_on_close():
+    """Called before I2S deinit: soft-mute the DAC to suppress pops."""
+    if _es8311:
+        _es8311.dac_mute(True)
+        _time.sleep_ms(20)
+
+
+if _es8311:
+    from mpos import AudioManager
+
+    AudioManager.add(
+        AudioManager.Output(
+            name="Speaker",
+            kind="i2s",
+            channels=1,
+            i2s_pins={
+                'mck': 12,  # MCLK - 256 x sample_rate during playback
+                'sck': 13,  # BCLK
+                'ws':  15,  # LRCK
+                'sd':  16,  # I2S TX (ESP32 -> ES8311 DAC)
+            },
+            on_open=_audio_on_open,
+            on_close=_audio_on_close,
+        )
+    )
+
+    AudioManager.add(
+        AudioManager.Input(
+            name="Microphone",
+            kind="i2s",
+            channels=1,
+            i2s_pins={
+                'mck':   12,
+                'sck':   13,
+                'ws':    15,
+                'sd_in': 14,  # I2S RX (ES8311 ADC -> ESP32)
+            },
+            preferred_sample_rate=16000,
+        )
+    )
+
 # === CAMERA ===
 # The board has a camera CONNECTOR (OV5640/OV2640 supported) but no camera is
 # included. Camera init is intentionally not set up here; if you attach one,

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -291,7 +291,7 @@ CameraManager.add_camera(CameraManager.Camera(
     deinit=deinit_cam,
     capture=capture_cam,
     apply_settings=apply_cam_settings,
-    rotation_degrees=-90,  # tuned on hardware: preview needs 90 degrees clockwise correction
+    rotation_degrees=90,  # tuned on hardware (was -90 for the _90 UI; flipped with the _270 orientation)
 ))
 
 if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py finished")

--- a/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
+++ b/internal_filesystem/lib/mpos/board/waveshare_esp32_s3_touch_lcd_3_5.py
@@ -214,9 +214,81 @@ if _es8311:
     )
 
 # === CAMERA ===
-# The board has a camera CONNECTOR (OV5640/OV2640 supported) but no camera is
-# included. Camera init is intentionally not set up here; if you attach one,
-# see waveshare_esp32_s3_touch_lcd_2.py for the CameraManager pattern (the
-# connector pinout is in the schematic linked above).
+# The board has a camera connector (OV5640/OV2640 supported, none included).
+# Pins from Waveshare's demo code (03_camera_web_server): the SCCB control
+# bus shares the board's main I2C pins (sda=8/scl=7) with touch/codec/
+# expander — Waveshare's own examples drive them together, and the sensor
+# is auto-detected by the camera driver. PWDN/RESET are not wired (-1).
+from mpos import CameraManager
+
+
+def init_cam(width, height, colormode):
+    toreturn = None
+    try:
+        from camera import Camera, GrabMode, PixelFormat
+
+        frame_size = CameraManager.resolution_to_framesize(width, height)
+        if __debug__: logger.debug("init_cam: FrameSize %s for %sx%s" % (frame_size, width, height))
+
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                cam = Camera(
+                        data_pins=[45, 47, 48, 46, 42, 40, 39, 21],  # Y2..Y9
+                        vsync_pin=17,
+                        href_pin=18,
+                        # SCCB shares the board's main I2C bus (sda=8/scl=7)
+                        # with touch/codec/expander. Reuse the existing bus
+                        # driver (port 0) instead of fighting it: concurrent
+                        # touch polling otherwise garbles sensor config
+                        # (wrong colors) and touch reads (dead buttons).
+                        sda_pin=-1,
+                        scl_pin=-1,
+                        sccb_i2c_port=0,
+                        pclk_pin=41,
+                        xclk_pin=38,
+                        xclk_freq=20000000,
+                        powerdown_pin=-1,
+                        reset_pin=-1,
+                        pixel_format=PixelFormat.RGB565 if colormode else PixelFormat.GRAYSCALE,
+                        frame_size=frame_size,
+                        grab_mode=GrabMode.LATEST,
+                        fb_count=1
+                    )
+                toreturn = cam
+                break
+            except Exception as e:
+                if attempt < max_attempts - 1:
+                    logger.error("init_cam attempt %s failed: %s, retrying..." % (attempt, e))
+                else:
+                    logger.error("init_cam final exception: %s" % (e))
+                    break
+    except Exception as e:
+        logger.error("init_cam exception: %s" % (e))
+    return toreturn
+
+
+def deinit_cam(cam):
+    cam.deinit()
+
+
+def capture_cam(cam_obj, colormode):
+    return cam_obj.capture()
+
+
+def apply_cam_settings(cam_obj, prefs):
+    return CameraManager.ov_apply_camera_settings(cam_obj, prefs)
+
+
+CameraManager.add_camera(CameraManager.Camera(
+    lens_facing=CameraManager.CameraCharacteristics.LENS_FACING_BACK,
+    name="Camera connector (OV5640/OV2640)",
+    vendor="OmniVision",
+    init=init_cam,
+    deinit=deinit_cam,
+    capture=capture_cam,
+    apply_settings=apply_cam_settings,
+    rotation_degrees=-90,  # tuned on hardware: preview needs 90 degrees clockwise correction
+))
 
 if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5.py finished")

--- a/internal_filesystem/lib/mpos/main.py
+++ b/internal_filesystem/lib/mpos/main.py
@@ -245,6 +245,16 @@ def detect_board():
                     return "fri3d_2024"
                 restore_i2c(sda=9, scl=18)
 
+            if __debug__: logger.debug("waveshare_esp32_s3_touch_lcd_3_5 ?")
+            if i2c0 := fail_save_i2c(sda=8, scl=7):
+                # PCA9554 IO expander (LCD reset/CS) + FT6336 touch: this pair on
+                # this bus is unique to the ESP32-S3-Touch-LCD-3.5 (the freenove
+                # board's FT6336G sits on sda=16/scl=15, the unihiker's expander
+                # on sda=47/scl=48).
+                if single_address_i2c_scan(i2c0, 0x20) and single_address_i2c_scan(i2c0, 0x38):
+                    return "waveshare_esp32_s3_touch_lcd_3_5"
+                restore_i2c(sda=8, scl=7)
+
         else: # not is_esp32s3
 
             if __debug__: logger.debug("m5stack_core2 ?")

--- a/tests/test_graphical_campreview_scaleblit.py
+++ b/tests/test_graphical_campreview_scaleblit.py
@@ -1,0 +1,120 @@
+"""
+Graphical regression test for camera preview color fidelity through the
+LVGL image blit, both 1:1 and scaled.
+
+Motivation: on the Waveshare ESP32-S3-Touch-LCD-3.5, the camera preview
+renders with badly wrong colors ("x-ray") even though the raw RGB565
+frames from the sensor are correct. The one structural difference from
+boards where preview colors are fine (e.g. Touch-LCD-2) is that the
+preview image is scaled (set_scale != 256), which sends the blit through
+LVGL's software transform path instead of a plain copy.
+
+This test feeds a synthetic RGB565 color-bar frame through the real
+CameraActivity preview widget and samples the rendered screen:
+- test_scaled_preview_colors: 192x192 source scaled to 240x240 (scale=320)
+- test_unscaled_preview_colors: forced scale=256 control
+"""
+
+import struct
+import unittest
+
+import lvgl as lv
+
+import mpos.ui
+from mpos import CameraManager
+from mpos.ui.camera_activity import CameraActivity
+from mpos.ui.testing import capture_screenshot, wait_for_render
+
+SRC_W = 192
+SRC_H = 192
+
+# 6 vertical bars in RGB565: red, green, blue, white, black, yellow
+BAR_COLORS = [0xF800, 0x07E0, 0x001F, 0xFFFF, 0x0000, 0xFFE0]
+
+
+def make_colorbar_frame():
+    bar_w = SRC_W // len(BAR_COLORS)
+    row = b''.join(
+        struct.pack('<H', BAR_COLORS[min(x // bar_w, len(BAR_COLORS) - 1)])
+        for x in range(SRC_W)
+    )
+    return row * SRC_H
+
+
+def rgb565_to_rgb888(v):
+    r = (v >> 11) & 0x1F
+    g = (v >> 5) & 0x3F
+    b = v & 0x1F
+    return (r * 255 // 31, g * 255 // 63, b * 255 // 31)
+
+
+class TestCameraPreviewScaledBlit(unittest.TestCase):
+
+    def setUp(self):
+        self.saved_cameras = CameraManager._cameras
+        CameraManager._cameras = [
+            CameraManager.Camera(
+                lens_facing=CameraManager.CameraCharacteristics.LENS_FACING_FRONT,
+                rgb565_byte_swap=False,
+                rotation_degrees=0,
+            )
+        ]
+        self.frame = make_colorbar_frame()
+
+    def tearDown(self):
+        CameraManager._cameras = self.saved_cameras
+        if getattr(self, 'activity', None) and self.activity.image:
+            self.activity.image_dsc.data = None
+            self.activity.image.delete()
+
+    def _show_preview(self):
+        self.activity = CameraActivity()
+        self.activity.image = lv.image(lv.screen_active())
+        self.activity.image.set_pos(0, 0)
+        self.activity.width = SRC_W
+        self.activity.height = SRC_H
+        self.activity.colormode = True
+        self.activity.update_preview_image()
+        self.activity.image_dsc.data = self.frame
+        self.activity.image.set_src(self.activity.image_dsc)
+
+    def _screenshot(self):
+        self.shot_w = mpos.ui.DisplayMetrics.width()
+        self.shot_h = mpos.ui.DisplayMetrics.height()
+        return capture_screenshot(width=self.shot_w, height=self.shot_h)
+
+    def _sample(self, shot, x, y):
+        v = struct.unpack_from('<H', shot, (y * self.shot_w + x) * 2)[0]
+        return rgb565_to_rgb888(v)
+
+    def _assert_bars(self, shot, rendered_w, msg):
+        bar_w = rendered_w // len(BAR_COLORS)
+        errors = []
+        for i, expected565 in enumerate(BAR_COLORS):
+            x = i * bar_w + bar_w // 2
+            got = self._sample(shot, x, 100)
+            want = rgb565_to_rgb888(expected565)
+            if any(abs(g - w) > 40 for g, w in zip(got, want)):
+                errors.append("bar %d at x=%d: want RGB%s got RGB%s" % (i, x, want, got))
+        self.assertFalse(errors, "%s: %s" % (msg, "; ".join(errors)))
+
+    def test_scaled_preview_colors(self):
+        self._show_preview()
+        # e.g. 320x240 display -> target 240, scale 240*256/192 = 320
+        scale = self.activity.image.get_scale_x()
+        self.assertNotEqual(scale, 256, "test setup expects a scaled preview")
+        wait_for_render()
+        shot = self._screenshot()
+        rendered_w = SRC_W * scale // 256
+        self._assert_bars(shot, rendered_w, "scaled blit (scale=%d)" % scale)
+
+    def test_unscaled_preview_colors(self):
+        self._show_preview()
+        self.activity.image.set_scale(256)  # force 1:1 control
+        wait_for_render()
+        shot = self._screenshot()
+        self._assert_bars(shot, SRC_W, "1:1 blit (scale=256)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #280 (board support, incl. the new st7796 INVON commit) and #281 (ES8311 audio) — only the last commit is new here. Depends on MicroPythonOS/micropython-camera-API#1 for the `sccb_i2c_port` parameter.

Adds camera support for the 3.5's DVP connector, pins from Waveshare's 03_camera_web_server demo. Three hardware-debugging findings are baked in:

1. **Shared SCCB/I2C bus**: the camera's SCCB control lines are the board's main I2C pins (sda=8/scl=7), shared with touch/codec/expander. The camera must reuse the existing bus driver (`sda_pin=-1, sccb_i2c_port=0`) — with its own second driver on those pins, touch polling garbles SCCB traffic (corrupted sensor config, dead touch buttons during preview).
2. **rotation_degrees=-90**: the sensor is mounted 90° CCW relative to the landscape UI (tuned with a real OV5640).
3. **No rgb565_byte_swap**: the sensor's RGB565 output is native little-endian, matching LVGL's render format. The "wrong preview colors" seen during bring-up turned out to be the missing INVON in the st7796 driver (see #280) inverting the whole panel, not a camera byte-order issue.

Verified on hardware end to end: preview upright, natural colors, responsive buttons, QR scanning works. Also adds a desktop graphical regression test asserting RGB565 preview color fidelity through the LVGL image blit at 1:1 and scaled sizes (passes on desktop; guards the preview path used by all camera boards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)