### PR TITLE
deeplink: fold query keys to lowercase; accept www.badgehub.eu

### DIFF
--- a/internal_filesystem/lib/mpos/content/deeplink.py
+++ b/internal_filesystem/lib/mpos/content/deeplink.py
@@ -34,7 +34,7 @@ MAX_URL_LENGTH = 512
 MAX_APP_ID_LENGTH = 64
 MAX_PARAM_LENGTH = 64
 
-STORE_HOSTS = ("badgehub.eu",)
+STORE_HOSTS = ("badgehub.eu", "www.badgehub.eu")
 STORE_SCHEMES = ("micropythonos", "mpos")
 APPSTORE_FULLNAME = "com.micropythonos.appstore"
 
@@ -89,7 +89,11 @@ def split_url(text):
 
 
 def _parse_query(query):
-    """Parse a query string into a dict; malformed pairs are skipped."""
+    """Parse a query string into a dict; malformed pairs are skipped.
+
+    Keys are folded to lowercase (QR alphanumeric mode uppercases the
+    whole payload); values are kept as-is.
+    """
     params = {}
     if not query:
         return params
@@ -97,7 +101,7 @@ def _parse_query(query):
         eq = pair.find("=")
         if eq <= 0:
             continue
-        key = pair[:eq]
+        key = pair[:eq].lower()
         value = pair[eq + 1:]
         if len(value) > MAX_PARAM_LENGTH:
             continue

--- a/tests/test_deeplink.py
+++ b/tests/test_deeplink.py
@@ -61,6 +61,19 @@ class TestParseStoreLink(unittest.TestCase):
             self.assertIsNotNone(link, text)
             self.assertEqual(link["fullname"], "com.example.paint", text)
 
+    def test_www_host_accepted(self):
+        link = deeplink.parse_store_link("https://www.badgehub.eu/page/project/com.example.paint")
+        self.assertIsNotNone(link)
+        self.assertEqual(link["fullname"], "com.example.paint")
+
+    def test_uppercase_query_keys(self):
+        # QR alphanumeric mode uppercases the query keys as well as the path.
+        link = deeplink.parse_store_link(
+            "HTTPS://BADGEHUB.EU/PAGE/PROJECT/COM.EXAMPLE.PAINT?V=1.2&S=BADGE")
+        self.assertIsNotNone(link)
+        self.assertEqual(link["min_version"], "1.2")
+        self.assertEqual(link["source"], "BADGE")
+
     def test_surrounding_whitespace_stripped(self):
         link = deeplink.parse_store_link("  https://badgehub.eu/page/project/com.example.paint\n")
         self.assertIsNotNone(link)
@@ -132,6 +145,8 @@ class TestHandlerPatternValidation(unittest.TestCase):
     def test_reserved_store_host_rejected(self):
         self.assertIsNotNone(deeplink.validate_handler_pattern(
             "https://badgehub.eu/page/project/*"))
+        self.assertIsNotNone(deeplink.validate_handler_pattern(
+            "https://www.badgehub.eu/page/project/*"))
 
     def test_reserved_scheme_rejected(self):
         self.assertIsNotNone(deeplink.validate_handler_pattern("micropythonos://app/*"))


### PR DESCRIPTION
Small follow-up on top of 9e72e7f7 (the BadgeHub switch), which supersedes the original version of this PR. One commit:

- **Query parameter keys are case-folded** like the rest of the link: the module contract says QR alphanumeric-mode uppercasing is handled everywhere, but `?V=1.2` silently dropped the version parameter. Test added.
- **`www.badgehub.eu`** accepted alongside `badgehub.eu`, and reserved from third-party `urlPattern` handlers the same way.

(The optional legacy `apps.micropythonos.com` recognition was dropped per review — the feature was never officially released, so no such QR codes exist in the wild.)

Tests: `test_deeplink.py` plus the scanqr and camera-chip graphical suites pass on the desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)