### PR TITLE
build_mpos.sh: apply lvgl_micropython's SDL release-2.32.8 patch for unix/macOS builds

### DIFF
--- a/scripts/build_mpos.sh
+++ b/scripts/build_mpos.sh
@@ -422,6 +422,18 @@ elif [ "$target" == "unix" -o "$target" == "macOS" ]; then
 	ensure_mpconfig_define MICROPY_PY_WEBREPL
 	ensure_mpconfig_define MICROPY_PY_OS_DUPTERM
 
+	# builder/unix.py force-checks-out SDL release-2.30.2, which no longer
+	# compiles on macOS with current Xcode Command Line Tools (SDL_cocoawindow.m
+	# messages the forward-declared SDLOpenGLContext when SDL_OPENGL is off;
+	# recent clang makes that an error). SDL fixed it on the 2.32 line, so the
+	# patch moves the checkout to release-2.32.8. Existence-guarded so MPOS
+	# still builds against older pinned lvgl_micropython SHAs without it.
+	sdl_patch="$codebasedir"/lvgl_micropython/unix_sdl_release_2_32_8.patch
+	if [ -f "$sdl_patch" ]; then
+		echo "Applying lvgl_micropython SDL release-2.32.8 checkout patch..."
+		apply_patch "$codebasedir"/lvgl_micropython "$sdl_patch"
+	fi
+
 	# sdl2 has been removed from Homebrew in favor of sdl2-compat on some runners,
 	# but the lvgl_micropython macOS builder still queries the sdl2 formula. Point
 	# it at sdl2-compat so the brew info / LDFLAGS / CFLAGS discovery works.


### PR DESCRIPTION
Companion to MicroPythonOS/lvgl_micropython#10, reworked per review there into a `.patch` file (`unix_sdl_release_2_32_8.patch`) like the other build-time patches instead of editing `builder/unix.py` in the submodule.

This applies it in the unix/macOS section of the build, existence-guarded like the newer patches so builds against older pinned lvgl_micropython SHAs keep working. `apply_patch` is idempotent (forward dry-run, or already-applied detection), verified both ways.

Background: SDL `release-2.30.2` no longer compiles on macOS with current Xcode Command Line Tools; SDL fixed it on the 2.32 maintenance line. Merge order: lvgl_micropython#10 first, then bump the submodule pointer, then this (or merge this first — the guard makes it a no-op until the patch file exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)