### PR TITLE
tests: use Lightning Piggy's current publisher name in the BadgeHub fixture

### DIFF
--- a/tests/test_appstore_async_refresh.py
+++ b/tests/test_appstore_async_refresh.py
@@ -825,7 +825,7 @@ class TestAppDetailRefreshBeforeAddButtons(unittest.TestCase):
             '"name":"Lightning Piggy",'
             '"description":"Display wallet",'
             '"long_description":"See https://www.LightningPiggy.com",'
-            '"author":"LightningPiggy Foundation",'
+            '"author":"The Lightning Piggy Project",'
             '"icon_map":{"64x64":"icon-64x64.png"},'
             '"version":"0.6.0",'
             '"badges":["mpos_api_0"]}}}'


### PR DESCRIPTION
One-line fixture tidy-up: the mocked BadgeHub project response in `test_appstore_async_refresh.py` still carried the old publisher "LightningPiggy Foundation". The app's manifest is "The Lightning Piggy Project" (shipping on BadgeHub with 0.7.3), so align the fixture. No behavior change; the test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)