### PR TITLE
Nostr: keep the MessagePool across watchdog reconnects; count any NWC event as activity

### DIFF
--- a/internal_filesystem/apps/com_micropythonos_nostr/nostr_service.py
+++ b/internal_filesystem/apps/com_micropythonos_nostr/nostr_service.py
@@ -1228,6 +1228,14 @@ class NostrManager:
 
     def _process_nwc_event(self, event):
         """Decrypt and process an NWC response/notification event."""
+        # Any event on the NWC subscription is wallet-service activity, even
+        # one we cannot decrypt or do not understand: the relay delivered it,
+        # so reconnecting the relay cannot help. Reset the silence watchdog
+        # here, before decryption, instead of only on usable results.
+        if self._polls_since_last_event > 0:
+            if __debug__:
+                logger.debug("NostrManager: NWC watchdog counter reset (event kind=%s)", getattr(event, "kind", "?"))
+        self._polls_since_last_event = 0
         try:
             decrypted = self._nwc_private_key.decrypt_message(
                 event.content,
@@ -1304,15 +1312,34 @@ class NostrManager:
         """Watchdog reconnect: close, wait, reopen, re-subscribe."""
         logger.warning("NostrManager: watchdog reconnecting relay (silent for %s polls)",
             self._polls_since_last_event)
+        old_manager = self.relay_manager
         try:
-            await self.relay_manager.close_connections()
+            await old_manager.close_connections()
         except Exception as e:
-                    logger.warning("NostrManager: close during reconnect failed: %s", e)
+            logger.warning("NostrManager: close during reconnect failed: %s", e)
+
+        # close_connections() can fail part-way (it is best-effort per relay),
+        # leaving websocket tasks alive. Make sure none survive the swap: a
+        # surviving task keeps delivering into its relay's bound pool.
+        old_relays = getattr(old_manager, 'relays', {}) or {}
+        for relay in old_relays.values():
+            task = getattr(relay, 'task', None)
+            if task is not None:
+                try:
+                    task.cancel()
+                except Exception:
+                    pass
 
         await TaskManager.sleep(2)
 
-        old_relay_urls = list(self.relay_manager.relays.keys()) if hasattr(self.relay_manager, 'relays') else []
+        old_relay_urls = list(old_relays.keys())
         self.relay_manager = RelayManager()
+        # Keep the ONE message pool for the lifetime of the manager: the
+        # consumer loop polls self.relay_manager.message_pool, and every Relay
+        # binds the pool it was given at add_relay() time. A fresh pool here
+        # would split-brain the receive path — anything still delivered by a
+        # not-yet-dead old websocket lands in the old pool that nobody reads.
+        self.relay_manager.message_pool = old_manager.message_pool
         self._relay_connected_state = {}
         for url in old_relay_urls:
             self.relay_manager.add_relay(url)

--- a/tests/test_nostr_nwc_errors.py
+++ b/tests/test_nostr_nwc_errors.py
@@ -31,6 +31,7 @@ class _FakeKey:
 
 
 class _FakeEvent:
+    kind = 23195
     content = "irrelevant-ciphertext"
     public_key = "wallet-pubkey"
 
@@ -124,6 +125,125 @@ class TestNwcErrorSurfacing(unittest.TestCase):
     def test_error_without_cb_does_not_raise(self):
         mgr = _bare_manager(_ERROR_REPLY)
         mgr._process_nwc_event(_FakeEvent())
+
+
+class _RaisingKey:
+    def decrypt_message(self, content, pubkey):
+        raise ValueError("bad ciphertext")
+
+
+class TestNwcWatchdogCountsAnyEvent(unittest.TestCase):
+    """Bug 2 of #287 (broad form): any event on the NWC subscription is
+    wallet-service activity and must reset the silence watchdog, even if it
+    cannot be decrypted or carries neither result nor error."""
+
+    def test_unknown_reply_resets_watchdog(self):
+        mgr = _bare_manager(json.dumps({"result_type": "something_new"}))
+        mgr._process_nwc_event(_FakeEvent())
+        self.assertEqual(mgr._polls_since_last_event, 0)
+
+    def test_undecryptable_reply_resets_watchdog(self):
+        mgr = _bare_manager("unused")
+        mgr._nwc_private_key = _RaisingKey()
+        mgr._process_nwc_event(_FakeEvent())  # must not raise
+        self.assertEqual(mgr._polls_since_last_event, 0)
+
+
+class _FakeTask:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class _FakeRelay:
+    def __init__(self, url, pool):
+        self.url = url
+        self.message_pool = pool
+        self.task = _FakeTask()
+        self.connected = True
+
+
+class _FakeRelayManager:
+    """Mimics nostr.relay_manager.RelayManager: a fresh MessagePool per
+    instance, relays bind the pool current at add_relay() time."""
+    instances = []
+
+    def __init__(self, fail_close=False):
+        self.message_pool = object()
+        self.relays = {}
+        self._fail_close = fail_close
+        _FakeRelayManager.instances.append(self)
+
+    def add_relay(self, url, *a, **kw):
+        self.relays[url] = _FakeRelay(url, self.message_pool)
+
+    async def close_connections(self):
+        if self._fail_close:
+            raise OSError("socket already gone")
+
+    async def open_connections(self, *a, **kw):
+        return None
+
+    def connected_relays(self):
+        return len(self.relays)
+
+
+class TestReconnectKeepsMessagePool(unittest.TestCase):
+    """Bug 3 of #287: the watchdog reconnect must not split-brain the receive
+    path. The rebuilt manager reuses the existing MessagePool (so relays
+    added afterwards, and any old websocket still delivering, feed the pool
+    the consumer loop reads) and old relay tasks are cancelled even when
+    close_connections() fails part-way."""
+
+    def setUp(self):
+        import asyncio
+        asyncio.new_event_loop()
+        import nostr_service
+        self._orig_rm = nostr_service.RelayManager
+        self._orig_sleep = nostr_service.TaskManager.sleep
+        nostr_service.RelayManager = _FakeRelayManager
+
+        async def _no_sleep(*a, **kw):
+            return None
+        nostr_service.TaskManager.sleep = _no_sleep
+        _FakeRelayManager.instances = []
+
+    def tearDown(self):
+        import nostr_service
+        nostr_service.RelayManager = self._orig_rm
+        nostr_service.TaskManager.sleep = self._orig_sleep
+
+    def _reconnect(self, fail_close):
+        import asyncio
+        mgr = _bare_manager("unused")
+        old = _FakeRelayManager(fail_close=fail_close)
+        old.add_relay("wss://relay.example")
+        old_pool = old.message_pool
+        old_task = old.relays["wss://relay.example"].task
+        mgr.relay_manager = old
+        mgr.keep_running = True
+        mgr._relay_connected_state = {}
+        mgr._subscription_ids = {}
+        mgr._send_subscriptions_to_relays = lambda urls: None
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(mgr._reconnect_relay())
+        return mgr, old, old_pool, old_task
+
+    def test_pool_reused_and_tasks_cancelled_on_clean_close(self):
+        mgr, old, old_pool, old_task = self._reconnect(fail_close=False)
+        self.assertIsNot(mgr.relay_manager, old)
+        self.assertIs(mgr.relay_manager.message_pool, old_pool)
+        self.assertIs(mgr.relay_manager.relays["wss://relay.example"].message_pool, old_pool)
+        self.assertTrue(old_task.cancelled)
+        self.assertEqual(mgr._polls_since_last_event, 0)
+
+    def test_pool_reused_and_tasks_cancelled_when_close_fails(self):
+        mgr, old, old_pool, old_task = self._reconnect(fail_close=True)
+        self.assertIs(mgr.relay_manager.message_pool, old_pool)
+        self.assertIs(mgr.relay_manager.relays["wss://relay.example"].message_pool, old_pool)
+        self.assertTrue(old_task.cancelled)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #288, addressing the rest of #287 (bug 3, and bug 2 in its broad form). Fixes #287.

## Bug 3 — reconnect split-brain
`_reconnect_relay()` built a fresh `RelayManager` — and with it a fresh `MessagePool` — right after a best-effort `close_connections()` that can fail part-way and leave websocket tasks alive. Each `Relay` binds the pool it was given at `add_relay()` time, so a surviving old websocket kept delivering into the **old** pool while the consumer loop polled the **new**, empty one. After an unclean reconnect, events were received and enqueued where nobody read them — the watchdog turned from a recovery mechanism into a way to permanently wedge the receive path.

Fix (no library change needed): the rebuilt manager reuses the existing pool (`relay_manager.message_pool = old.message_pool` before the `add_relay()` calls, so new relays bind to it too), and every old relay task is cancelled explicitly even when `close_connections()` raised.

## Bug 2 — watchdog, broad form
Since #288 the silence counter resets on results and error replies. Any event on the NWC subscription is wallet-service activity (reconnecting the relay cannot help), so the reset now happens at the top of `_process_nwc_event`, before decryption — undecryptable or unknown replies count too.

## Tests
`test_nostr_nwc_errors.py`: +4 — reconnect with a clean and with a failing close (pool identity preserved, new relays bound to it, old task cancelled, counter reset); unknown and undecryptable replies reset the watchdog. Driven with a fake `RelayManager` that mirrors the real one's pool-per-instance behavior; `TaskManager.sleep` is patched to a no-op for the test. All 10 NWC tests plus the 16 other `test_nostr_*` files pass on the desktop build; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)